### PR TITLE
Fix issues connecting from Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Thumbs.db
 *.log
 .vscode/
 target/
+.claude/settings.local.json

--- a/crates/iris-dev-bin/src/cmd/mcp.rs
+++ b/crates/iris-dev-bin/src/cmd/mcp.rs
@@ -71,8 +71,9 @@ impl McpCommand {
             };
             if let Some(ref c) = conn {
                 tracing::info!(
-                    "IRIS connected: {} v{}",
+                    "IRIS connected: {}/api/atelier/{} {}",
                     c.base_url,
+                    c.atelier_version.version_str(),
                     c.version.as_deref().unwrap_or("?")
                 );
             } else {

--- a/crates/iris-dev-core/src/iris/connection.rs
+++ b/crates/iris-dev-core/src/iris/connection.rs
@@ -80,6 +80,38 @@ impl IrisConnection {
         self.atelier_url(&format!("/{}/{}{}", v, self.namespace, path))
     }
 
+    /// Probe this connection: fetch IRIS version and Atelier API level from `/api/atelier/`.
+    pub async fn probe(&mut self) {
+        let client = match Self::http_client() {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        let url = self.atelier_url("/");
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .send()
+            .await
+        {
+            let status = resp.status();
+            if status.is_success() {
+                if let Ok(body) = resp.json::<serde_json::Value>().await {
+                    tracing::debug!("Atelier root response: {}", body);
+                    let content = &body["result"]["content"];
+                    self.version = content["version"].as_str().map(|v| v.to_string());
+                    self.atelier_version = match content["api"].as_u64() {
+                        Some(v) if v >= 8 => AtelierVersion::V8,
+                        Some(v) if v >= 2 => AtelierVersion::V2,
+                        _ => AtelierVersion::V1,
+                    };
+                }
+            } else {
+                tracing::debug!("Atelier root probe got HTTP {}", status);
+            }
+        }
+    }
+
     /// Detect the highest available Atelier API version by probing.
     /// Sets self.atelier_version in place.
     pub async fn detect_version(&mut self, client: &reqwest::Client) {

--- a/crates/iris-dev-core/src/iris/discovery.rs
+++ b/crates/iris-dev-core/src/iris/discovery.rs
@@ -44,9 +44,10 @@ pub async fn probe_atelier(
     }
 
     let body: serde_json::Value = resp.json().await.ok()?;
+    let content = &body["result"]["content"];
 
-    // Fingerprint: result.content[0].version must contain "IRIS"
-    let version = body["result"]["content"][0]["version"]
+    // Fingerprint: result.content.version must contain "IRIS"
+    let version = content["version"]
         .as_str()
         .filter(|v| v.to_uppercase().contains("IRIS"))
         .map(|v| v.to_string())?;
@@ -59,13 +60,19 @@ pub async fn probe_atelier(
         DiscoverySource::LocalhostScan { port },
     );
     conn.version = Some(version);
+    conn.atelier_version = match content["api"].as_u64() {
+        Some(v) if v >= 8 => crate::iris::connection::AtelierVersion::V8,
+        Some(v) if v >= 2 => crate::iris::connection::AtelierVersion::V2,
+        _ => crate::iris::connection::AtelierVersion::V1,
+    };
     Some(conn)
 }
 
 /// Full discovery cascade. Returns Ok(Some(conn)) if IRIS found, Ok(None) if not.
 pub async fn discover_iris(explicit: Option<IrisConnection>) -> Result<Option<IrisConnection>> {
-    // 1. Explicit wins immediately
-    if let Some(conn) = explicit {
+    // 1. Explicit wins immediately — but probe for version + Atelier API level first
+    if let Some(mut conn) = explicit {
+        conn.probe().await;
         return Ok(Some(conn));
     }
 

--- a/crates/iris-dev-core/src/tools/mod.rs
+++ b/crates/iris-dev-core/src/tools/mod.rs
@@ -127,6 +127,8 @@ pub struct CommunityPkgParams {
     pub name: String,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct NoParams {}
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SourceMapParams {
     pub cls_text: String,
     pub cls_name: String,
@@ -1302,7 +1304,7 @@ Methods:
     #[tool(description = "List all synthesized skills in the registry.")]
     async fn skill_list(
         &self,
-        _: Parameters<serde_json::Value>,
+        _: Parameters<NoParams>,
     ) -> Result<CallToolResult, McpError> {
         if let Some(iris) = self.iris.as_deref() {
             let client = self.http_client();
@@ -1395,7 +1397,7 @@ Methods:
     )]
     async fn skill_propose(
         &self,
-        _: Parameters<serde_json::Value>,
+        _: Parameters<NoParams>,
     ) -> Result<CallToolResult, McpError> {
         ok_json(
             serde_json::json!({"triggered": true, "note": "pattern mining pending full learning agent port"}),
@@ -1429,7 +1431,7 @@ Methods:
     )]
     async fn skill_community_list(
         &self,
-        _: Parameters<serde_json::Value>,
+        _: Parameters<NoParams>,
     ) -> Result<CallToolResult, McpError> {
         let skills: Vec<_> = self
             .registry
@@ -1541,7 +1543,7 @@ Methods:
     #[tool(description = "Return learning agent status: skill count, pattern count, KB size.")]
     async fn agent_stats(
         &self,
-        _: Parameters<serde_json::Value>,
+        _: Parameters<NoParams>,
     ) -> Result<CallToolResult, McpError> {
         let mut skill_count = serde_json::Value::Null;
         if let Some(iris) = self.iris.as_deref() {
@@ -1602,7 +1604,7 @@ Methods:
     )]
     async fn interop_production_needs_update(
         &self,
-        _: Parameters<serde_json::Value>,
+        _: Parameters<NoParams>,
     ) -> Result<CallToolResult, McpError> {
         interop::interop_production_needs_update_impl(self.iris.as_deref()).await
     }
@@ -1610,7 +1612,7 @@ Methods:
     #[tool(description = "Recover a troubled IRIS Interoperability production.")]
     async fn interop_production_recover(
         &self,
-        _: Parameters<serde_json::Value>,
+        _: Parameters<NoParams>,
     ) -> Result<CallToolResult, McpError> {
         interop::interop_production_recover_impl(self.iris.as_deref()).await
     }
@@ -1628,7 +1630,7 @@ Methods:
     #[tool(description = "Get all current Interoperability message queues and their depths.")]
     async fn interop_queues(
         &self,
-        _: Parameters<serde_json::Value>,
+        _: Parameters<NoParams>,
     ) -> Result<CallToolResult, McpError> {
         interop::interop_queues_impl(self.iris.as_deref()).await
     }

--- a/crates/iris-dev-core/src/tools/mod.rs
+++ b/crates/iris-dev-core/src/tools/mod.rs
@@ -1302,10 +1302,7 @@ Methods:
     }
 
     #[tool(description = "List all synthesized skills in the registry.")]
-    async fn skill_list(
-        &self,
-        _: Parameters<NoParams>,
-    ) -> Result<CallToolResult, McpError> {
+    async fn skill_list(&self, _: Parameters<NoParams>) -> Result<CallToolResult, McpError> {
         if let Some(iris) = self.iris.as_deref() {
             let client = self.http_client();
             let code = "Set key=\"\" Set result=\"[\" For { Set key=$Order(^SKILLS(key)) Quit:key=\"\" Set skill=$Get(^SKILLS(key)) Set result=result_skill_\",\" } Set result=$Extract(result,1,$Length(result)-1)_\"]\" Write result";
@@ -1395,10 +1392,7 @@ Methods:
     #[tool(
         description = "Trigger pattern miner to synthesize new skills from recorded tool calls."
     )]
-    async fn skill_propose(
-        &self,
-        _: Parameters<NoParams>,
-    ) -> Result<CallToolResult, McpError> {
+    async fn skill_propose(&self, _: Parameters<NoParams>) -> Result<CallToolResult, McpError> {
         ok_json(
             serde_json::json!({"triggered": true, "note": "pattern mining pending full learning agent port"}),
         )
@@ -1541,10 +1535,7 @@ Methods:
     }
 
     #[tool(description = "Return learning agent status: skill count, pattern count, KB size.")]
-    async fn agent_stats(
-        &self,
-        _: Parameters<NoParams>,
-    ) -> Result<CallToolResult, McpError> {
+    async fn agent_stats(&self, _: Parameters<NoParams>) -> Result<CallToolResult, McpError> {
         let mut skill_count = serde_json::Value::Null;
         if let Some(iris) = self.iris.as_deref() {
             let client = self.http_client();
@@ -1628,10 +1619,7 @@ Methods:
     }
 
     #[tool(description = "Get all current Interoperability message queues and their depths.")]
-    async fn interop_queues(
-        &self,
-        _: Parameters<NoParams>,
-    ) -> Result<CallToolResult, McpError> {
+    async fn interop_queues(&self, _: Parameters<NoParams>) -> Result<CallToolResult, McpError> {
         interop::interop_queues_impl(self.iris.as_deref()).await
     }
 


### PR DESCRIPTION
Fixes #1 

This honestly seems like a set of more basic issues than "it doesn't work on Windows" - possibly related to connection / discovery mode? Like, has this ever worked at all?

At this point I'm at least able to connect + see tools from Claude Code and npx @modelcontextprotocol/inspector .

I tried to run tests but can't locally because of:
error[E0433]: cannot find `unix` in `os`
 --> crates\iris-dev-bin\tests\plugin_dispatch_tests.rs:3:14
  |
3 | use std::os::unix::fs::PermissionsExt;
  |              ^^^^ could not find `unix` in `os`
  |
note: found an item that was configured out
 --> /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library\std\src\os\mod.rs:29:4
  |
  = note: the item is gated here
note: found an item that was configured out
 --> /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library\std\src\os\mod.rs:84:40
  |
  = note: the item is gated here

For more information about this error, try `rustc --explain E0433`.
error: could not compile `iris-dev` (test "plugin_dispatch_tests") due to 1 previous error
warning: build failed, waiting for other jobs to finish...