### PR TITLE
VSIX: implement IRIS_TLS_VERIFY env variable

### DIFF
--- a/vscode-iris-dev/package.json
+++ b/vscode-iris-dev/package.json
@@ -1,9 +1,13 @@
 {
   "name": "vscode-iris-dev",
   "displayName": "iris-dev for IRIS",
-  "description": "Wires iris-dev MCP tools into VS Code Copilot agent mode — automatically picks up your objectscript.conn connection. Requires the iris-dev binary on PATH.",
+  "description": "Wires iris-dev MCP tools into VS Code Copilot agent mode — automatically picks up your objectscript.conn connection. Requires the iris-dev binary on PATH or in `iris-dev.serverPath` setting.",
   "version": "0.2.4",
   "publisher": "intersystems-community",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intersystems-community/iris-dev"
+  },
   "engines": {
     "vscode": "^1.99.0"
   },

--- a/vscode-iris-dev/src/extension.ts
+++ b/vscode-iris-dev/src/extension.ts
@@ -108,6 +108,10 @@ export class IrisDevMcpProvider
       .get<string>('containerName');
     this.log.info(`iris-dev: containerName = ${containerName}`);
 
+    const tlsVerify = vscode.workspace
+      .getConfiguration('http')
+      .get<boolean>('proxyStrictSSL');
+
     // Resolve named server if using intersystems.servers.
     // Server Manager writes server definitions to user settings, so we must
     // check both workspace-scoped config (for .vscode/settings.json) and
@@ -167,6 +171,7 @@ export class IrisDevMcpProvider
       IRIS_ISFS: isIsfs ? 'true' : undefined,
       IRIS_SERVER_NAME: conn.server ?? undefined,
       IRIS_CONTAINER: containerName ?? undefined,
+      IRIS_TLS_VERIFY: tlsVerify ? 'true' : 'false',
       OBJECTSCRIPT_LEARNING: 'true',
     };
     const env: Record<string, string | number> = Object.fromEntries(


### PR DESCRIPTION
This PR implements #49 by deriving IRIS_TLS_VERIFY (new in 0.4.21) from the user's `http.proxyStrictSSL` setting,

It also adds repository info to package.json, eliminating one of the warnings from `vsce package`.