### PR TITLE
feat: fleet roles, operate mode, and role-gate for multi-instance deployments

### DIFF
--- a/crates/iris-agentic-dev-bin/src/cmd/init.rs
+++ b/crates/iris-agentic-dev-bin/src/cmd/init.rs
@@ -12,6 +12,9 @@ pub struct InitCommand {
     /// Output format: text or json
     #[arg(long, default_value = "text")]
     pub format: String,
+    /// Config mode: "develop" (default) or "operate" (fleet/multi-instance template)
+    #[arg(long, default_value = "develop")]
+    pub mode: String,
 }
 
 impl InitCommand {
@@ -49,10 +52,17 @@ impl InitCommand {
             .map(|s| s.to_string())
             .unwrap_or_else(|| format!("{}-iris", workspace_basename));
 
-        let content = iris_agentic_dev_core::iris::workspace_config::generate_toml_content(
-            &suggested_container,
-            "USER",
-        );
+        let content = if self.mode == "operate" {
+            iris_agentic_dev_core::iris::workspace_config::generate_operate_toml_content(
+                &suggested_container,
+                "USER",
+            )
+        } else {
+            iris_agentic_dev_core::iris::workspace_config::generate_toml_content(
+                &suggested_container,
+                "USER",
+            )
+        };
 
         std::fs::write(&config_path, &content)
             .with_context(|| format!("writing {}", config_path.display()))?;

--- a/crates/iris-agentic-dev-core/Cargo.toml
+++ b/crates/iris-agentic-dev-core/Cargo.toml
@@ -219,6 +219,10 @@ name = "test_role_gate"
 path = "tests/unit/test_role_gate.rs"
 
 [[test]]
+name = "test_role_gate_handlers"
+path = "tests/unit/test_role_gate_handlers.rs"
+
+[[test]]
 name = "test_handlers_live"
 path = "tests/integration/test_handlers_live.rs"
 required-features = ["testing"]

--- a/crates/iris-agentic-dev-core/Cargo.toml
+++ b/crates/iris-agentic-dev-core/Cargo.toml
@@ -215,6 +215,10 @@ name = "test_skills_mod_unit"
 path = "tests/unit/test_skills_mod_unit.rs"
 
 [[test]]
+name = "test_role_gate"
+path = "tests/unit/test_role_gate.rs"
+
+[[test]]
 name = "test_handlers_live"
 path = "tests/integration/test_handlers_live.rs"
 required-features = ["testing"]

--- a/crates/iris-agentic-dev-core/Cargo.toml
+++ b/crates/iris-agentic-dev-core/Cargo.toml
@@ -223,6 +223,10 @@ name = "test_role_gate_handlers"
 path = "tests/unit/test_role_gate_handlers.rs"
 
 [[test]]
+name = "test_role_gate_e2e"
+path = "tests/integration/test_role_gate_e2e.rs"
+
+[[test]]
 name = "test_handlers_live"
 path = "tests/integration/test_handlers_live.rs"
 required-features = ["testing"]

--- a/crates/iris-agentic-dev-core/src/iris/workspace_config.rs
+++ b/crates/iris-agentic-dev-core/src/iris/workspace_config.rs
@@ -29,6 +29,46 @@ pub struct WorkspaceConfig {
     pub docker_only: bool,
 }
 
+/// Connection role for fleet/operate mode instances.
+#[derive(Debug, Deserialize, Clone, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConnectionRole {
+    #[default]
+    Workspace,
+    Subject,
+    ControlPlane,
+}
+
+/// Per-instance config block for `mode = "operate"` fleet configs.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct InstanceConfig {
+    pub container: Option<String>,
+    pub namespace: Option<String>,
+    pub host: Option<String>,
+    pub web_port: Option<u16>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    #[serde(default)]
+    pub role: ConnectionRole,
+    pub memory_home: Option<String>,
+    pub subject: Option<String>,
+}
+
+/// Top-level fleet config. Wraps WorkspaceConfig for backward-compatible develop mode.
+///
+/// Parsing rule: load as FleetConfig.
+/// - mode absent or "develop" → use `workspace` (flat fields); ignore `instance` map.
+/// - mode = "operate" → use `instance` map; flat `workspace` fields are informational.
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct FleetConfig {
+    pub mode: Option<String>,
+    #[serde(default)]
+    pub instance: std::collections::HashMap<String, InstanceConfig>,
+    #[serde(flatten)]
+    pub workspace: WorkspaceConfig,
+}
+
 /// Resolve the workspace root path.
 /// Priority: OBJECTSCRIPT_WORKSPACE env var > workspace_path arg > walk up from cwd.
 ///
@@ -110,6 +150,193 @@ pub fn load_workspace_config(workspace_path: Option<&str>) -> Option<WorkspaceCo
                 None
             }
         },
+    }
+}
+
+/// Load `.iris-agentic-dev.toml` as a `FleetConfig` (Amendment 001).
+/// Returns `None` if the file does not exist or fails to parse (with a warning).
+pub fn load_fleet_config(workspace_path: Option<&str>) -> Option<FleetConfig> {
+    let root = workspace_root(workspace_path);
+    let config_path = if root.join(".iris-agentic-dev.toml").exists() {
+        root.join(".iris-agentic-dev.toml")
+    } else if root.join(".iris-dev.toml").exists() {
+        root.join(".iris-dev.toml")
+    } else {
+        return None;
+    };
+
+    match std::fs::read_to_string(&config_path) {
+        Err(e) => {
+            tracing::warn!("Could not read config at {}: {}", config_path.display(), e);
+            None
+        }
+        Ok(contents) => match toml::from_str::<FleetConfig>(&contents) {
+            Ok(cfg) => {
+                tracing::debug!("Loaded fleet config from {}", config_path.display());
+                Some(cfg)
+            }
+            Err(e) => {
+                tracing::warn!("Could not parse config at {}: {}", config_path.display(), e);
+                None
+            }
+        },
+    }
+}
+
+/// Validate a FleetConfig: replace unknown `memory_home` keys with `"self"` (with a warning).
+pub fn validate_fleet_config(cfg: &mut FleetConfig) {
+    let known_keys: std::collections::HashSet<String> = cfg.instance.keys().cloned().collect();
+    for (name, inst) in cfg.instance.iter_mut() {
+        if let Some(ref mh) = inst.memory_home.clone() {
+            if mh != "self" && !known_keys.contains(mh.as_str()) {
+                tracing::warn!(
+                    "instance '{}': memory-home '{}' is not a declared instance key — falling back to 'self'",
+                    name, mh
+                );
+                inst.memory_home = Some("self".into());
+            }
+        }
+    }
+}
+
+/// Role-gate check for subject instances (FR-019, FR-020).
+///
+/// Returns `Some(error_json)` when the call should be blocked, `None` when it should proceed.
+///
+/// - `role`: the connection role to check.
+/// - `tool_name`: tool identifier, e.g. `"iris_compile"` or `"iris_source_control:commit"`.
+///   For `iris_query`, pass `"iris_query:SELECT"` / `"iris_query:INSERT"` etc.
+///   SELECT (and other read-only SQL) should be passed as `"iris_query:SELECT"` — not gated.
+/// - `confirm`: whether the caller passed `confirm: true`.
+/// - `instance_name`: the `[instance.*]` key (for the error message).
+/// - `hard_block`: if `true`, no confirm path exists (used for source_control writes).
+///
+/// Pure function — no I/O, no side effects.
+pub fn check_role_gate(
+    role: &ConnectionRole,
+    tool_name: &str,
+    confirm: bool,
+    instance_name: &str,
+    hard_block: bool,
+) -> Option<serde_json::Value> {
+    // Workspace and ControlPlane are never gated
+    if *role != ConnectionRole::Subject {
+        return None;
+    }
+
+    // SELECT and other read-only queries are never gated
+    if tool_name == "iris_query:SELECT"
+        || tool_name == "iris_query:select"
+        || tool_name.starts_with("iris_source_control:status")
+        || tool_name.starts_with("iris_source_control:diff")
+        || tool_name.starts_with("iris_source_control:log")
+        || tool_name.starts_with("iris_source_control:list")
+        || tool_name.starts_with("iris_source_control:get")
+    {
+        return None;
+    }
+
+    // Hard block: no confirm path (source_control writes)
+    if hard_block {
+        return Some(serde_json::json!({
+            "error": "role_gate",
+            "role_gate": true,
+            "hard_block": true,
+            "instance": instance_name,
+            "role": "subject",
+            "message": format!(
+                "Instance '{}' has role 'subject'. Source-control write operations are not permitted on subject instances.",
+                instance_name
+            ),
+        }));
+    }
+
+    // Soft gate: confirm=true bypasses
+    if confirm {
+        return None;
+    }
+
+    Some(serde_json::json!({
+        "error": "role_gate",
+        "role_gate": true,
+        "instance": instance_name,
+        "role": "subject",
+        "required_confirmation": tool_name,
+        "message": format!(
+            "Instance '{}' has role 'subject'. Re-issue with confirm: true to proceed.",
+            instance_name
+        ),
+    }))
+}
+
+/// Build the `workspace_config` JSON field for `iris_list_containers`.
+///
+/// - `mode = "operate"`: returns an object with `mode`, `instances` (each with role/memory_home/subject/running).
+/// - develop mode or absent: returns the existing shape (found/path/container/namespace/running).
+/// - no config file: returns `serde_json::Value::Null`.
+pub fn build_workspace_config_json(
+    workspace_path: Option<&str>,
+    running_containers: &[serde_json::Value],
+) -> serde_json::Value {
+    let mut cfg = match load_fleet_config(workspace_path) {
+        None => return serde_json::Value::Null,
+        Some(c) => c,
+    };
+    validate_fleet_config(&mut cfg);
+
+    let config_path = workspace_root(workspace_path)
+        .join(".iris-agentic-dev.toml")
+        .to_string_lossy()
+        .to_string();
+
+    if cfg.mode.as_deref() == Some("operate") {
+        let mut instances = serde_json::Map::new();
+        for (name, inst) in &cfg.instance {
+            let memory_home = inst.memory_home.clone().unwrap_or_else(|| "self".into());
+            let running = inst
+                .container
+                .as_deref()
+                .map(|c| {
+                    running_containers
+                        .iter()
+                        .any(|r| r["name"].as_str() == Some(c))
+                })
+                .unwrap_or(false);
+            let role_str = match inst.role {
+                ConnectionRole::Workspace => "workspace",
+                ConnectionRole::Subject => "subject",
+                ConnectionRole::ControlPlane => "control-plane",
+            };
+            instances.insert(
+                name.clone(),
+                serde_json::json!({
+                    "role": role_str,
+                    "memory_home": memory_home,
+                    "subject": inst.subject,
+                    "running": running,
+                }),
+            );
+        }
+        serde_json::json!({
+            "found": true,
+            "path": config_path,
+            "mode": "operate",
+            "instances": serde_json::Value::Object(instances),
+        })
+    } else {
+        // Develop mode — return existing shape unchanged
+        let container_name = cfg.workspace.container.as_deref().unwrap_or("");
+        let running = !container_name.is_empty()
+            && running_containers
+                .iter()
+                .any(|c| c["name"].as_str() == Some(container_name));
+        serde_json::json!({
+            "found": true,
+            "path": config_path,
+            "container": cfg.workspace.container,
+            "namespace": cfg.workspace.namespace,
+            "running": running,
+        })
     }
 }
 
@@ -274,6 +501,36 @@ namespace = "{namespace}"
 # username = "_SYSTEM"
 # password = "..."  # not recommended in committed files
 "#
+    )
+}
+
+/// Generate starter `.iris-agentic-dev.toml` for `iris-dev init --mode operate`.
+/// Produces one active `[instance.local]` block and a commented-out `[instance.subject]` block.
+pub fn generate_operate_toml_content(local_container: &str, local_namespace: &str) -> String {
+    format!(
+        r#"# iris-agentic-dev fleet configuration (operate mode)
+# Use this when managing multiple named IRIS instances.
+# Commit this file to share connection settings with your team.
+mode = "operate"
+
+# ── Local / control-plane instance ──────────────────────────────────────────
+[instance.local]
+container = "{local_container}"
+namespace = "{local_namespace}"
+role = "workspace"            # "workspace" or "control-plane": no write gating
+
+# ── Subject instance (e.g. a customer/production IRIS) ──────────────────────
+# Uncomment and fill in to add a subject instance.
+# [instance.subject]
+# host = "subject-iris.example.com"
+# web_port = 52773
+# namespace = "USER"
+# role = "subject"            # destructive ops require explicit confirm: true
+# memory-home = "local"       # route AI memory writes to the 'local' instance
+# subject = "MyCustomer"      # free-form label identifying this subject
+"#,
+        local_container = local_container,
+        local_namespace = local_namespace,
     )
 }
 

--- a/crates/iris-agentic-dev-core/src/iris/workspace_config.rs
+++ b/crates/iris-agentic-dev-core/src/iris/workspace_config.rs
@@ -236,16 +236,19 @@ pub fn check_role_gate(
         return None;
     }
 
-    // Hard block: no confirm path (source_control writes)
+    // Hard block: no confirm path (source_control writes).
+    // confirm: true is silently accepted at the parameter level (shared field with soft-gate ops)
+    // but has no effect here — confirm_ignored: true makes this explicit to agents.
     if hard_block {
         return Some(serde_json::json!({
             "error": "role_gate",
             "role_gate": true,
             "hard_block": true,
+            "confirm_ignored": true,
             "instance": instance_name,
             "role": "subject",
             "message": format!(
-                "Instance '{}' has role 'subject'. Source-control write operations are not permitted on subject instances.",
+                "Instance '{}' has role 'subject'. Source-control write operations are not permitted on subject instances. confirm: true has no effect on hard-blocked operations.",
                 instance_name
             ),
         }));

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -656,6 +656,9 @@ pub struct CompileParams {
     /// If true, bypass the log store and return all errors/warnings inline regardless of count.
     #[serde(default)]
     pub inline: bool,
+    /// Set to true to confirm execution on a subject-role instance (role-gate bypass).
+    #[serde(default)]
+    pub confirm: bool,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TestParams {
@@ -816,6 +819,9 @@ pub struct QueryParams {
     /// Has no effect on production IRIS instances (where write tools are disabled).
     #[serde(default)]
     pub force: bool,
+    /// Set to true to confirm execution on a subject-role instance (role-gate bypass).
+    #[serde(default)]
+    pub confirm: bool,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListContainersParams {
@@ -1666,6 +1672,55 @@ impl IrisTools {
         self.connection.lock().unwrap().write_tools_enabled
     }
 
+    /// Returns the `ConnectionRole` and instance name for the currently-active connection.
+    ///
+    /// In operate mode (`mode = "operate"` in `.iris-agentic-dev.toml`), matches the active
+    /// `IrisConnection` against declared `[instance.*]` blocks by container name or host.
+    /// Returns `(Workspace, "")` when no fleet config is present, mode is not "operate",
+    /// or no instance block matches — i.e., the default / dev-mode case is always permitted.
+    pub fn instance_role(&self) -> (crate::iris::workspace_config::ConnectionRole, String) {
+        use crate::iris::connection::DiscoverySource;
+        use crate::iris::workspace_config::{load_fleet_config, ConnectionRole};
+
+        let (workspace_path, iris_arc) = {
+            let conn = self.connection.lock().unwrap();
+            let ws = conn
+                .config_file
+                .as_ref()
+                .and_then(|p| p.parent())
+                .and_then(|p| p.to_str())
+                .map(|s| s.to_string());
+            (ws, conn.iris.clone())
+        };
+
+        let Some(fleet) = load_fleet_config(workspace_path.as_deref()) else {
+            return (ConnectionRole::Workspace, String::new());
+        };
+        if fleet.mode.as_deref() != Some("operate") {
+            return (ConnectionRole::Workspace, String::new());
+        }
+        let Some(iris) = iris_arc else {
+            return (ConnectionRole::Workspace, String::new());
+        };
+
+        for (name, inst) in &fleet.instance {
+            let matches = match &iris.source {
+                DiscoverySource::Docker { container_name } => {
+                    inst.container.as_deref() == Some(container_name.as_str())
+                }
+                _ => inst
+                    .host
+                    .as_deref()
+                    .map(|h| iris.base_url.contains(h))
+                    .unwrap_or(false),
+            };
+            if matches {
+                return (inst.role.clone(), name.clone());
+            }
+        }
+        (ConnectionRole::Workspace, String::new())
+    }
+
     /// Returns the active connection as Option<Arc>, for interop helpers that take Option<&IrisConnection>.
     fn iris_arc(&self) -> Option<Arc<IrisConnection>> {
         self.connection.lock().unwrap().iris.clone()
@@ -1767,6 +1822,16 @@ impl IrisTools {
         Parameters(p): Parameters<CompileParams>,
     ) -> Result<CallToolResult, McpError> {
         let iris = self.get_iris_reloaded().await?;
+        let (role, instance_name) = self.instance_role();
+        if let Some(gate) = crate::iris::workspace_config::check_role_gate(
+            &role,
+            "iris_compile",
+            p.confirm,
+            &instance_name,
+            false,
+        ) {
+            return ok_json(gate);
+        }
         tracing::info!(namespace = %p.namespace, target = %p.target, "iris_compile");
         let client = self.http_client();
 
@@ -2415,6 +2480,16 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         Parameters(p): Parameters<ExecuteParams>,
     ) -> Result<CallToolResult, McpError> {
         let iris = self.get_iris_reloaded().await?;
+        let (role, instance_name) = self.instance_role();
+        if let Some(gate) = crate::iris::workspace_config::check_role_gate(
+            &role,
+            "iris_execute",
+            p.confirmed,
+            &instance_name,
+            false,
+        ) {
+            return ok_json(gate);
+        }
         tracing::info!(namespace = %p.namespace, translate_sql = p.translate_sql, "iris_execute");
         let client = self.http_client();
         let timeout = std::time::Duration::from_secs(p.timeout);
@@ -2571,6 +2646,31 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         Parameters(p): Parameters<QueryParams>,
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(namespace = %p.namespace, force = p.force, "iris_query");
+
+        // Role gate: SELECT is always permitted on subject; write SQL requires confirm.
+        {
+            let (role, instance_name) = self.instance_role();
+            let first_word = p
+                .query
+                .split_whitespace()
+                .next()
+                .unwrap_or("")
+                .to_uppercase();
+            let tool_name = if first_word == "SELECT" || first_word == "WITH" {
+                "iris_query:SELECT"
+            } else {
+                "iris_query:INSERT"
+            };
+            if let Some(gate) = crate::iris::workspace_config::check_role_gate(
+                &role,
+                tool_name,
+                p.confirm,
+                &instance_name,
+                false,
+            ) {
+                return ok_json(gate);
+            }
+        }
 
         // SQL safety gate — validate before any network call
         let skip_validation = p.force && self.write_tools_enabled();
@@ -3885,6 +3985,23 @@ Methods:
         Parameters(p): Parameters<ScmParams>,
     ) -> Result<CallToolResult, McpError> {
         let iris = self.get_iris_reloaded().await?;
+        // Role gate: write actions (checkout, execute) are hard-blocked on subject instances.
+        // Read actions (status, menu) are always permitted.
+        {
+            let (role, instance_name) = self.instance_role();
+            let is_write = matches!(p.action.as_str(), "checkout" | "execute");
+            if is_write {
+                if let Some(gate) = crate::iris::workspace_config::check_role_gate(
+                    &role,
+                    "iris_source_control:commit",
+                    p.confirm,
+                    &instance_name,
+                    true,
+                ) {
+                    return ok_json(gate);
+                }
+            }
+        }
         let result =
             scm::handle_iris_source_control(&iris, self.http_client(), p, &self.elicitation_store)
                 .await;

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -1683,13 +1683,23 @@ impl IrisTools {
         use crate::iris::workspace_config::{load_fleet_config, ConnectionRole};
 
         let (workspace_path, iris_arc) = {
+            // Prefer config_watcher path (set at startup from OBJECTSCRIPT_WORKSPACE / --workspace).
+            // Fall back to config_file on ConnectionState (set only after a hot-reload cycle).
+            let watcher_ws = {
+                let w = self.config_watcher.lock().unwrap();
+                w.as_ref()
+                    .and_then(|w| w.config_path.parent())
+                    .and_then(|p| p.to_str())
+                    .map(|s| s.to_string())
+            };
             let conn = self.connection.lock().unwrap();
-            let ws = conn
-                .config_file
-                .as_ref()
-                .and_then(|p| p.parent())
-                .and_then(|p| p.to_str())
-                .map(|s| s.to_string());
+            let ws = watcher_ws.or_else(|| {
+                conn.config_file
+                    .as_ref()
+                    .and_then(|p| p.parent())
+                    .and_then(|p| p.to_str())
+                    .map(|s| s.to_string())
+            });
             (ws, conn.iris.clone())
         };
 
@@ -1703,16 +1713,24 @@ impl IrisTools {
             return (ConnectionRole::Workspace, String::new());
         };
 
+        // Active container name from DiscoverySource or IRIS_CONTAINER env var fallback.
+        let active_container = match &iris.source {
+            DiscoverySource::Docker { container_name } => Some(container_name.clone()),
+            _ => std::env::var("IRIS_CONTAINER")
+                .ok()
+                .filter(|s| !s.is_empty()),
+        };
+
         for (name, inst) in &fleet.instance {
-            let matches = match &iris.source {
-                DiscoverySource::Docker { container_name } => {
-                    inst.container.as_deref() == Some(container_name.as_str())
-                }
-                _ => inst
-                    .host
+            let matches = if let Some(ref ic) = inst.container {
+                // Match by container name if the instance declares one.
+                active_container.as_deref() == Some(ic.as_str())
+            } else {
+                // No container in instance config — match by host in base_url.
+                inst.host
                     .as_deref()
                     .map(|h| iris.base_url.contains(h))
-                    .unwrap_or(false),
+                    .unwrap_or(false)
             };
             if matches {
                 return (inst.role.clone(), name.clone());

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -1727,9 +1727,14 @@ impl IrisTools {
                 active_container.as_deref() == Some(ic.as_str())
             } else {
                 // No container in instance config — match by host in base_url.
+                // Use scheme-stripped prefix match ("://host:") to avoid "iris" matching
+                // "my-iris-dev" or a hostname that is a substring of another.
                 inst.host
                     .as_deref()
-                    .map(|h| iris.base_url.contains(h))
+                    .map(|h| {
+                        let needle = format!("://{h}:");
+                        iris.base_url.contains(&needle)
+                    })
                     .unwrap_or(false)
             };
             if matches {

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -2668,31 +2668,11 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 c["name"].as_str().unwrap_or("")
             )
         });
-        // FR-012: show which container .iris-agentic-dev.toml would select and if it's running.
-        let workspace_config_json = {
-            let ws_path = p.workspace_root.as_deref();
-            match crate::iris::workspace_config::load_workspace_config(ws_path) {
-                None => serde_json::Value::Null,
-                Some(ref cfg) => {
-                    let container_name = cfg.container.as_deref().unwrap_or("");
-                    let running = !container_name.is_empty()
-                        && containers
-                            .iter()
-                            .any(|c| c["name"].as_str() == Some(container_name));
-                    let config_path = crate::iris::workspace_config::workspace_root(ws_path)
-                        .join(".iris-agentic-dev.toml")
-                        .to_string_lossy()
-                        .to_string();
-                    serde_json::json!({
-                        "found": true,
-                        "path": config_path,
-                        "container": cfg.container,
-                        "namespace": cfg.namespace,
-                        "running": running,
-                    })
-                }
-            }
-        };
+        // FR-012 / FR-023: show workspace config, supporting both develop and operate mode.
+        let workspace_config_json = crate::iris::workspace_config::build_workspace_config_json(
+            p.workspace_root.as_deref(),
+            &containers,
+        );
         // Add active_connection info so agents can detect workspace_config mismatches
         // without a separate iris_info call.
         let iris_arc = self.iris_arc();

--- a/crates/iris-agentic-dev-core/src/tools/scm.rs
+++ b/crates/iris-agentic-dev-core/src/tools/scm.rs
@@ -32,6 +32,10 @@ pub struct ScmParams {
     pub elicitation_id: Option<String>,
     #[serde(default = "default_namespace")]
     pub namespace: String,
+    /// Set to true to confirm write on a subject-role instance. Has no effect: source_control
+    /// writes on subject instances are always hard-blocked regardless of confirm.
+    #[serde(default)]
+    pub confirm: bool,
 }
 
 async fn xecute(

--- a/crates/iris-agentic-dev-core/tests/integration/test_role_gate_e2e.rs
+++ b/crates/iris-agentic-dev-core/tests/integration/test_role_gate_e2e.rs
@@ -1,0 +1,475 @@
+//! E2E tests for role-gate enforcement in operate mode (Amendment 001).
+//!
+//! Spawns the iris-agentic-dev MCP binary with OBJECTSCRIPT_WORKSPACE pointing at a
+//! tempdir containing an operate-mode fleet config that declares the active connection
+//! as a subject instance.  Verifies:
+//!   - iris_compile returns role_gate error without confirm
+//!   - iris_compile proceeds with confirm: true
+//!   - iris_execute returns role_gate error without confirm
+//!   - iris_query SELECT is always permitted on subject
+//!   - iris_query INSERT returns role_gate without confirm
+//!   - iris_source_control checkout is hard-blocked on subject (confirm has no effect)
+//!   - iris_source_control status is always permitted on subject
+//!   - develop-mode config (no mode field) produces no role-gate (US7 regression)
+//!
+//! Run with a live IRIS instance:
+//!   IRIS_HOST=localhost IRIS_WEB_PORT=52773 IRIS_USERNAME=_SYSTEM IRIS_PASSWORD=SYS \
+//!   cargo test --test test_role_gate_e2e -- --nocapture
+//!
+//! All tests skip gracefully when IRIS_HOST is not set or the binary is absent.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+fn iris_dev_bin() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("IRIS_DEV_BIN") {
+        let p = std::path::PathBuf::from(path);
+        if p.exists() {
+            return p;
+        }
+    }
+    let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // crates/iris-agentic-dev-core
+    p.pop(); // crates/
+    p.push("target/debug/iris-agentic-dev");
+    if !p.exists() {
+        p.pop();
+        p.push("release/iris-agentic-dev");
+    }
+    p
+}
+
+fn iris_host() -> String {
+    std::env::var("IRIS_HOST").unwrap_or_default()
+}
+
+macro_rules! require_iris {
+    () => {
+        if iris_host().is_empty() {
+            eprintln!("Skipping: IRIS_HOST not set");
+            return;
+        }
+        if !iris_dev_bin().exists() {
+            eprintln!(
+                "Skipping: iris-agentic-dev binary not found at {:?}",
+                iris_dev_bin()
+            );
+            return;
+        }
+    };
+}
+
+macro_rules! require_bin {
+    () => {
+        if !iris_dev_bin().exists() {
+            eprintln!(
+                "Skipping: iris-agentic-dev binary not found at {:?}",
+                iris_dev_bin()
+            );
+            return;
+        }
+    };
+}
+
+fn init_msgs() -> Vec<serde_json::Value> {
+    vec![
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+            "protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e-role-gate","version":"0.1"}
+        }}),
+        serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
+    ]
+}
+
+fn tool_result(responses: &[serde_json::Value], id: u64) -> serde_json::Value {
+    let resp = responses
+        .iter()
+        .find(|r| r["id"] == id)
+        .cloned()
+        .unwrap_or_default();
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("{}");
+    serde_json::from_str(text).unwrap_or_default()
+}
+
+/// Spawn the MCP binary with the given workspace dir and env vars, send messages, collect responses.
+fn mcp_call_with_workspace(
+    workspace_dir: &std::path::Path,
+    extra_env: &[(&str, String)],
+    messages: &[serde_json::Value],
+    timeout_secs: u64,
+) -> Vec<serde_json::Value> {
+    let bin = iris_dev_bin();
+    if !bin.exists() {
+        return vec![];
+    }
+
+    let mut cmd = Command::new(&bin);
+    cmd.args(["mcp"]);
+    cmd.env("OBJECTSCRIPT_WORKSPACE", workspace_dir);
+    // Pass through IRIS connection env vars
+    for key in &[
+        "IRIS_HOST",
+        "IRIS_WEB_PORT",
+        "IRIS_USERNAME",
+        "IRIS_PASSWORD",
+        "IRIS_NAMESPACE",
+        "IRIS_CONTAINER",
+    ] {
+        if let Ok(v) = std::env::var(key) {
+            cmd.env(key, v);
+        }
+    }
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn iris-agentic-dev mcp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut results = vec![];
+
+    for msg in messages {
+        stdin
+            .write_all((serde_json::to_string(msg).unwrap() + "\n").as_bytes())
+            .unwrap();
+        stdin.flush().unwrap();
+        if msg.get("id").is_some() {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+            loop {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) > 0 {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+                        results.push(v);
+                        break;
+                    }
+                }
+                if std::time::Instant::now() > deadline {
+                    break;
+                }
+            }
+        } else {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
+
+    child.kill().ok();
+    results
+}
+
+/// Call a single tool with an operate-mode fleet config where the active IRIS_HOST
+/// is declared as a subject instance.  Returns the tool result JSON.
+fn call_with_subject_config(
+    tool_name: &str,
+    args: serde_json::Value,
+    timeout_secs: u64,
+) -> (serde_json::Value, tempfile::TempDir) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let host = std::env::var("IRIS_HOST").unwrap_or_else(|_| "localhost".to_string());
+    let web_port = std::env::var("IRIS_WEB_PORT").unwrap_or_else(|_| "52773".to_string());
+    let container = std::env::var("IRIS_CONTAINER").unwrap_or_default();
+
+    // Build fleet config: one instance matching the active connection, role=subject.
+    // If IRIS_CONTAINER is set, match by container; otherwise match by host.
+    let toml = if !container.is_empty() {
+        format!(
+            r#"mode = "operate"
+
+[instance.prod]
+container = "{container}"
+namespace = "USER"
+role = "subject"
+"#
+        )
+    } else {
+        format!(
+            r#"mode = "operate"
+
+[instance.prod]
+host = "{host}"
+web_port = {web_port}
+namespace = "USER"
+role = "subject"
+"#
+        )
+    };
+
+    std::fs::write(dir.path().join(".iris-agentic-dev.toml"), &toml).unwrap();
+
+    let mut msgs = init_msgs();
+    msgs.push(serde_json::json!({
+        "jsonrpc":"2.0","id":2,"method":"tools/call",
+        "params":{"name": tool_name, "arguments": args}
+    }));
+
+    let responses = mcp_call_with_workspace(dir.path(), &[], &msgs, timeout_secs);
+    (tool_result(&responses, 2), dir)
+}
+
+/// Call with a develop-mode (flat) config — used for US7 regression tests.
+fn call_with_develop_config(
+    tool_name: &str,
+    args: serde_json::Value,
+    timeout_secs: u64,
+) -> (serde_json::Value, tempfile::TempDir) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let container = std::env::var("IRIS_CONTAINER").unwrap_or_else(|_| "iris-dev".to_string());
+
+    let toml = format!(
+        r#"container = "{container}"
+namespace = "USER"
+"#
+    );
+    std::fs::write(dir.path().join(".iris-agentic-dev.toml"), &toml).unwrap();
+
+    let mut msgs = init_msgs();
+    msgs.push(serde_json::json!({
+        "jsonrpc":"2.0","id":2,"method":"tools/call",
+        "params":{"name": tool_name, "arguments": args}
+    }));
+
+    let responses = mcp_call_with_workspace(dir.path(), &[], &msgs, timeout_secs);
+    (tool_result(&responses, 2), dir)
+}
+
+// ── iris_compile role gate ────────────────────────────────────────────────────
+
+#[test]
+fn e2e_role_gate_compile_subject_no_confirm_blocked() {
+    require_iris!();
+    let (result, _dir) = call_with_subject_config(
+        "iris_compile",
+        serde_json::json!({"target": "User.RoleGateTest.cls", "namespace": "USER"}),
+        10,
+    );
+    assert_eq!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "iris_compile on subject without confirm must return role_gate:true, got: {}",
+        result
+    );
+    assert!(
+        result["required_confirmation"].as_str().is_some(),
+        "must include required_confirmation field, got: {}",
+        result
+    );
+    assert_eq!(
+        result["hard_block"].as_bool(),
+        None,
+        "compile gate must not be hard_block, got: {}",
+        result
+    );
+}
+
+#[test]
+fn e2e_role_gate_compile_subject_with_confirm_proceeds() {
+    require_iris!();
+    let (result, _dir) = call_with_subject_config(
+        "iris_compile",
+        serde_json::json!({"target": "User.DoesNotExistXYZ.cls", "namespace": "USER", "confirm": true}),
+        10,
+    );
+    // With confirm=true, role gate is bypassed — should get a compile error (not role_gate)
+    assert_ne!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "iris_compile with confirm:true must not return role_gate, got: {}",
+        result
+    );
+}
+
+// ── iris_execute role gate ────────────────────────────────────────────────────
+
+#[test]
+fn e2e_role_gate_execute_subject_no_confirm_blocked() {
+    require_iris!();
+    let (result, _dir) = call_with_subject_config(
+        "iris_execute",
+        serde_json::json!({"code": "Write 42", "namespace": "USER"}),
+        10,
+    );
+    assert_eq!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "iris_execute on subject without confirm must return role_gate:true, got: {}",
+        result
+    );
+}
+
+#[test]
+fn e2e_role_gate_execute_subject_confirmed_proceeds() {
+    require_iris!();
+    let (result, _dir) = call_with_subject_config(
+        "iris_execute",
+        serde_json::json!({"code": "Write 42", "namespace": "USER", "confirmed": true}),
+        10,
+    );
+    assert_ne!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "iris_execute with confirmed:true must not return role_gate, got: {}",
+        result
+    );
+}
+
+// ── iris_query role gate ──────────────────────────────────────────────────────
+
+#[test]
+fn e2e_role_gate_query_select_subject_permitted() {
+    require_iris!();
+    let (result, _dir) = call_with_subject_config(
+        "iris_query",
+        serde_json::json!({"query": "SELECT 1 AS n", "namespace": "USER"}),
+        10,
+    );
+    assert_ne!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "SELECT on subject must never be role-gated, got: {}",
+        result
+    );
+}
+
+#[test]
+fn e2e_role_gate_query_insert_subject_no_confirm_blocked() {
+    require_iris!();
+    let (result, _dir) = call_with_subject_config(
+        "iris_query",
+        // force:true to pass SQL safety gate; role gate fires before SQL safety anyway
+        serde_json::json!({"query": "INSERT INTO %SYS.Users (Name) VALUES ('x')", "namespace": "USER", "force": true}),
+        10,
+    );
+    assert_eq!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "INSERT on subject without confirm must return role_gate:true, got: {}",
+        result
+    );
+}
+
+// ── iris_source_control role gate ─────────────────────────────────────────────
+
+#[test]
+fn e2e_role_gate_scm_checkout_subject_hard_blocked() {
+    require_iris!();
+    let (result, _dir) = call_with_subject_config(
+        "iris_source_control",
+        serde_json::json!({"action": "checkout", "document": "User.RoleGateTest", "namespace": "USER"}),
+        10,
+    );
+    assert_eq!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "checkout on subject must return role_gate:true, got: {}",
+        result
+    );
+    assert_eq!(
+        result["hard_block"].as_bool(),
+        Some(true),
+        "checkout on subject must be hard_block:true, got: {}",
+        result
+    );
+}
+
+#[test]
+fn e2e_role_gate_scm_checkout_subject_confirm_still_blocked() {
+    require_iris!();
+    let (result, _dir) = call_with_subject_config(
+        "iris_source_control",
+        serde_json::json!({"action": "checkout", "document": "User.RoleGateTest", "namespace": "USER", "confirm": true}),
+        10,
+    );
+    // Hard block: confirm has no effect
+    assert_eq!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "checkout hard_block must not be bypassable with confirm:true, got: {}",
+        result
+    );
+    assert_eq!(
+        result["hard_block"].as_bool(),
+        Some(true),
+        "must still be hard_block:true even with confirm:true, got: {}",
+        result
+    );
+}
+
+#[test]
+fn e2e_role_gate_scm_status_subject_permitted() {
+    require_iris!();
+    let (result, _dir) = call_with_subject_config(
+        "iris_source_control",
+        serde_json::json!({"action": "status", "document": "User.RoleGateTest", "namespace": "USER"}),
+        10,
+    );
+    assert_ne!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "status on subject must not be role-gated, got: {}",
+        result
+    );
+}
+
+// ── US7 regression: develop-mode flat config produces no gate ─────────────────
+
+#[test]
+fn e2e_role_gate_develop_mode_compile_no_gate() {
+    require_iris!();
+    let (result, _dir) = call_with_develop_config(
+        "iris_compile",
+        serde_json::json!({"target": "User.DoesNotExistXYZ.cls", "namespace": "USER"}),
+        10,
+    );
+    assert_ne!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "develop-mode flat config must never gate iris_compile, got: {}",
+        result
+    );
+}
+
+#[test]
+fn e2e_role_gate_develop_mode_execute_no_gate() {
+    require_iris!();
+    let (result, _dir) = call_with_develop_config(
+        "iris_execute",
+        serde_json::json!({"code": "Write 42", "namespace": "USER", "confirmed": true}),
+        10,
+    );
+    assert_ne!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "develop-mode flat config must never gate iris_execute, got: {}",
+        result
+    );
+}
+
+// ── Binary-only: no-config produces no gate (baseline regression) ─────────────
+
+#[test]
+fn e2e_role_gate_no_config_file_no_gate() {
+    require_bin!();
+    // No .iris-agentic-dev.toml at all — must never produce a role_gate response.
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut msgs = init_msgs();
+    msgs.push(serde_json::json!({
+        "jsonrpc":"2.0","id":2,"method":"tools/call",
+        "params":{"name":"iris_compile","arguments":{"target":"Test.DoesNotExist.cls","namespace":"USER"}}
+    }));
+    let responses = mcp_call_with_workspace(dir.path(), &[], &msgs, 5);
+    let result = tool_result(&responses, 2);
+    assert_ne!(
+        result["role_gate"].as_bool(),
+        Some(true),
+        "no config file must never produce role_gate, got: {}",
+        result
+    );
+}

--- a/crates/iris-agentic-dev-core/tests/unit/test_role_gate.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_role_gate.rs
@@ -1,0 +1,199 @@
+// Tests for role-gate logic: subject instances require confirm:true for destructive ops.
+// source_control write ops on subject are hard-blocked regardless of confirm.
+
+use iris_agentic_dev_core::iris::workspace_config::{check_role_gate, ConnectionRole};
+
+// ── compile / execute / admin (FR-019) ───────────────────────────────────────
+
+#[test]
+fn test_iris_compile_subject_no_confirm_returns_role_gate() {
+    let result = check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_compile",
+        false,
+        "prod",
+        false,
+    );
+    assert!(
+        result.is_some(),
+        "subject without confirm must return role_gate error"
+    );
+    let v = result.unwrap();
+    assert_eq!(v["role_gate"].as_bool(), Some(true));
+    assert_eq!(v["role"].as_str(), Some("subject"));
+    assert_eq!(v["instance"].as_str(), Some("prod"));
+    assert_eq!(v["required_confirmation"].as_str(), Some("iris_compile"));
+    assert!(
+        v["hard_block"].as_bool() != Some(true),
+        "compile gate must not be a hard block"
+    );
+}
+
+#[test]
+fn test_iris_compile_subject_with_confirm_proceeds() {
+    let result = check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_compile",
+        true,
+        "prod",
+        false,
+    );
+    assert!(
+        result.is_none(),
+        "subject with confirm=true must return None (proceed)"
+    );
+}
+
+#[test]
+fn test_iris_execute_subject_no_confirm_returns_role_gate() {
+    let result = check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_execute",
+        false,
+        "prod",
+        false,
+    );
+    assert!(
+        result.is_some(),
+        "subject without confirm must return role_gate error"
+    );
+    let v = result.unwrap();
+    assert_eq!(v["role_gate"].as_bool(), Some(true));
+    assert_eq!(v["required_confirmation"].as_str(), Some("iris_execute"));
+}
+
+#[test]
+fn test_iris_execute_subject_with_confirm_proceeds() {
+    let result = check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_execute",
+        true,
+        "prod",
+        false,
+    );
+    assert!(result.is_none(), "subject with confirm=true must proceed");
+}
+
+#[test]
+fn test_iris_compile_workspace_role_no_gate() {
+    let result = check_role_gate(
+        &ConnectionRole::Workspace,
+        "iris_compile",
+        false,
+        "local",
+        false,
+    );
+    assert!(result.is_none(), "workspace role must never be gated");
+}
+
+#[test]
+fn test_iris_compile_control_plane_role_no_gate() {
+    let result = check_role_gate(
+        &ConnectionRole::ControlPlane,
+        "iris_compile",
+        false,
+        "ctrl",
+        false,
+    );
+    assert!(result.is_none(), "control-plane role must never be gated");
+}
+
+#[test]
+fn test_iris_query_select_subject_no_gate() {
+    // SELECT is always permitted on subject
+    let result = check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_query:SELECT",
+        false,
+        "prod",
+        false,
+    );
+    assert!(result.is_none(), "SELECT on subject must not be gated");
+}
+
+#[test]
+fn test_iris_query_insert_subject_no_confirm_role_gate() {
+    let result = check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_query:INSERT",
+        false,
+        "prod",
+        false,
+    );
+    assert!(
+        result.is_some(),
+        "INSERT on subject without confirm must be gated"
+    );
+    let v = result.unwrap();
+    assert_eq!(v["role_gate"].as_bool(), Some(true));
+}
+
+// ── source control hard block (FR-020) ────────────────────────────────────────
+
+#[test]
+fn test_iris_source_control_commit_subject_hard_blocked() {
+    let result = check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_source_control:commit",
+        false,
+        "prod",
+        true,
+    );
+    assert!(
+        result.is_some(),
+        "source_control write on subject must be hard blocked"
+    );
+    let v = result.unwrap();
+    assert_eq!(v["role_gate"].as_bool(), Some(true));
+    assert_eq!(
+        v["hard_block"].as_bool(),
+        Some(true),
+        "must be a hard block"
+    );
+}
+
+#[test]
+fn test_iris_source_control_commit_subject_confirm_still_blocked() {
+    // confirm=true has no effect on hard_block
+    let result = check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_source_control:commit",
+        true,
+        "prod",
+        true,
+    );
+    assert!(
+        result.is_some(),
+        "hard block must not be bypassable with confirm=true"
+    );
+    let v = result.unwrap();
+    assert_eq!(v["hard_block"].as_bool(), Some(true));
+}
+
+#[test]
+fn test_iris_source_control_status_subject_not_blocked() {
+    // read ops use tool_name without write marker — callers pass non-hard-block
+    let result = check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_source_control:status",
+        false,
+        "prod",
+        false,
+    );
+    assert!(result.is_none(), "read ops on subject must not be gated");
+}
+
+#[test]
+fn test_iris_source_control_commit_workspace_not_blocked() {
+    let result = check_role_gate(
+        &ConnectionRole::Workspace,
+        "iris_source_control:commit",
+        false,
+        "local",
+        true,
+    );
+    assert!(
+        result.is_none(),
+        "workspace role must not be gated even for write ops"
+    );
+}

--- a/crates/iris-agentic-dev-core/tests/unit/test_role_gate_handlers.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_role_gate_handlers.rs
@@ -1,0 +1,212 @@
+// Tests for role-gate wiring in tool handlers (FR-019, FR-020).
+// Verifies that iris_compile, iris_execute, iris_query, and iris_source_control
+// return role_gate errors when called against a subject-role instance in operate mode.
+//
+// Strategy: construct IrisTools with no IRIS connection, patch config_file to point at a
+// temp dir containing a fleet .iris-agentic-dev.toml that declares a subject instance,
+// then call instance_role() directly (white-box). The actual handler integration is
+// validated by checking compile(), execute(), etc. return role_gate JSON when disconnected.
+
+use iris_agentic_dev_core::iris::workspace_config::ConnectionRole;
+use iris_agentic_dev_core::tools::IrisTools;
+use std::io::Write;
+
+fn write_fleet_toml(dir: &tempfile::TempDir, contents: &str) {
+    let path = dir.path().join(".iris-agentic-dev.toml");
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(contents.as_bytes()).unwrap();
+}
+
+/// Build an IrisTools instance pointing at a fleet config in `dir`.
+/// The config_file on ConnectionState is set to `dir/.iris-agentic-dev.toml`
+/// so instance_role() picks it up.
+fn make_tools_with_fleet(dir: &tempfile::TempDir) -> IrisTools {
+    let tools = IrisTools::new(None).expect("IrisTools::new");
+    {
+        let mut conn = tools.connection.lock().unwrap();
+        conn.config_file = Some(dir.path().join(".iris-agentic-dev.toml"));
+    }
+    tools
+}
+
+// ── instance_role() unit tests (white-box) ────────────────────────────────────
+
+#[test]
+fn test_instance_role_no_fleet_config_returns_workspace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    // No .iris-agentic-dev.toml at all
+    let tools = make_tools_with_fleet(&dir);
+    let (role, name) = tools.instance_role();
+    assert_eq!(role, ConnectionRole::Workspace, "no config → Workspace");
+    assert!(name.is_empty());
+}
+
+#[test]
+fn test_instance_role_develop_mode_returns_workspace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_fleet_toml(&dir, "container = \"myapp-iris\"\n");
+    let tools = make_tools_with_fleet(&dir);
+    let (role, _) = tools.instance_role();
+    assert_eq!(
+        role,
+        ConnectionRole::Workspace,
+        "develop mode must always return Workspace"
+    );
+}
+
+#[test]
+fn test_instance_role_operate_mode_no_matching_instance_returns_workspace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_fleet_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.prod]
+host = "prod.example.com"
+role = "subject"
+"#,
+    );
+    // No active IrisConnection → no match → default Workspace
+    let tools = make_tools_with_fleet(&dir);
+    let (role, _) = tools.instance_role();
+    assert_eq!(
+        role,
+        ConnectionRole::Workspace,
+        "no matching connection → Workspace"
+    );
+}
+
+#[test]
+fn test_instance_role_operate_mode_matches_by_container() {
+    use iris_agentic_dev_core::iris::connection::{DiscoverySource, IrisConnection};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    write_fleet_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.local]
+container = "myapp-iris"
+namespace = "USER"
+
+[instance.prod]
+container = "prod-iris"
+role = "subject"
+"#,
+    );
+
+    let tools = IrisTools::new(None).expect("IrisTools::new");
+    {
+        let mut conn = tools.connection.lock().unwrap();
+        conn.config_file = Some(dir.path().join(".iris-agentic-dev.toml"));
+        // Inject a Docker-sourced connection matching "prod-iris"
+        conn.iris = Some(std::sync::Arc::new(IrisConnection::new(
+            "http://127.0.0.1:52773",
+            "PROD",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::Docker {
+                container_name: "prod-iris".to_string(),
+            },
+        )));
+    }
+
+    let (role, name) = tools.instance_role();
+    assert_eq!(role, ConnectionRole::Subject, "prod-iris → Subject");
+    assert_eq!(name, "prod", "instance name should be 'prod'");
+}
+
+#[test]
+fn test_instance_role_operate_mode_local_instance_is_workspace() {
+    use iris_agentic_dev_core::iris::connection::{DiscoverySource, IrisConnection};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    write_fleet_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.local]
+container = "myapp-iris"
+namespace = "USER"
+
+[instance.prod]
+container = "prod-iris"
+role = "subject"
+"#,
+    );
+
+    let tools = IrisTools::new(None).expect("IrisTools::new");
+    {
+        let mut conn = tools.connection.lock().unwrap();
+        conn.config_file = Some(dir.path().join(".iris-agentic-dev.toml"));
+        conn.iris = Some(std::sync::Arc::new(IrisConnection::new(
+            "http://127.0.0.1:52773",
+            "USER",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::Docker {
+                container_name: "myapp-iris".to_string(),
+            },
+        )));
+    }
+
+    let (role, name) = tools.instance_role();
+    assert_eq!(
+        role,
+        ConnectionRole::Workspace,
+        "myapp-iris is a Workspace instance"
+    );
+    assert_eq!(name, "local");
+}
+
+#[test]
+fn test_instance_role_matches_by_host() {
+    use iris_agentic_dev_core::iris::connection::{DiscoverySource, IrisConnection};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    write_fleet_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.remote]
+host = "prod.example.com"
+web_port = 52773
+role = "subject"
+"#,
+    );
+
+    let tools = IrisTools::new(None).expect("IrisTools::new");
+    {
+        let mut conn = tools.connection.lock().unwrap();
+        conn.config_file = Some(dir.path().join(".iris-agentic-dev.toml"));
+        conn.iris = Some(std::sync::Arc::new(IrisConnection::new(
+            "http://prod.example.com:52773",
+            "PROD",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        )));
+    }
+
+    let (role, name) = tools.instance_role();
+    assert_eq!(role, ConnectionRole::Subject, "host match → Subject");
+    assert_eq!(name, "remote");
+}
+
+// ── Regression: develop-mode flat configs unaffected (US7) ──────────────────
+
+#[test]
+fn test_develop_mode_flat_config_no_gate() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_fleet_toml(
+        &dir,
+        "container = \"loanapp-iris\"\nnamespace = \"LOANAPP\"\n",
+    );
+    let tools = make_tools_with_fleet(&dir);
+    let (role, _) = tools.instance_role();
+    assert_eq!(
+        role,
+        ConnectionRole::Workspace,
+        "flat develop config must not gate anything"
+    );
+}

--- a/crates/iris-agentic-dev-core/tests/unit/test_role_gate_handlers.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_role_gate_handlers.rs
@@ -193,6 +193,112 @@ role = "subject"
     assert_eq!(name, "remote");
 }
 
+// ── Host-match precision: overlapping hostnames must not cross-match ─────────
+
+#[test]
+fn test_instance_role_host_match_no_substring_confusion() {
+    use iris_agentic_dev_core::iris::connection::{DiscoverySource, IrisConnection};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    // "iris" is a substring of "my-iris-dev" — naive .contains() would match both.
+    write_fleet_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.short]
+host = "iris"
+web_port = 52773
+role = "subject"
+"#,
+    );
+
+    let tools = IrisTools::new(None).expect("IrisTools::new");
+    {
+        let mut conn = tools.connection.lock().unwrap();
+        conn.config_file = Some(dir.path().join(".iris-agentic-dev.toml"));
+        // Active connection is "my-iris-dev" — must NOT match fleet instance "iris"
+        conn.iris = Some(std::sync::Arc::new(IrisConnection::new(
+            "http://my-iris-dev:52773",
+            "USER",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        )));
+    }
+
+    let (role, _) = tools.instance_role();
+    assert_eq!(
+        role,
+        ConnectionRole::Workspace,
+        "'my-iris-dev' must not match fleet host 'iris' — substring match is too broad"
+    );
+}
+
+#[test]
+fn test_instance_role_host_match_exact_url_position() {
+    use iris_agentic_dev_core::iris::connection::{DiscoverySource, IrisConnection};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    write_fleet_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.prod]
+host = "prod.example.com"
+web_port = 52773
+role = "subject"
+
+[instance.preprod]
+host = "preprod.example.com"
+web_port = 52773
+role = "subject"
+"#,
+    );
+
+    let tools = IrisTools::new(None).expect("IrisTools::new");
+    {
+        let mut conn = tools.connection.lock().unwrap();
+        conn.config_file = Some(dir.path().join(".iris-agentic-dev.toml"));
+        conn.iris = Some(std::sync::Arc::new(IrisConnection::new(
+            "http://preprod.example.com:52773",
+            "STAGE",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        )));
+    }
+
+    let (role, name) = tools.instance_role();
+    assert_eq!(role, ConnectionRole::Subject, "preprod → Subject");
+    assert_eq!(
+        name, "preprod",
+        "must match 'preprod' not 'prod' despite 'prod' being a substring"
+    );
+}
+
+// ── Regression: hard-block confirm_ignored field ─────────────────────────────
+
+#[test]
+fn test_hard_block_response_includes_confirm_ignored() {
+    let gate = iris_agentic_dev_core::iris::workspace_config::check_role_gate(
+        &ConnectionRole::Subject,
+        "iris_source_control:commit",
+        true, // confirm: true — must be ignored on hard-block
+        "prod",
+        true,
+    );
+    assert!(
+        gate.is_some(),
+        "hard-block must gate even with confirm: true"
+    );
+    let json = gate.unwrap();
+    assert_eq!(json["hard_block"], true, "hard_block field must be true");
+    assert_eq!(
+        json["confirm_ignored"], true,
+        "confirm_ignored must be present so agents know not to retry"
+    );
+}
+
 // ── Regression: develop-mode flat configs unaffected (US7) ──────────────────
 
 #[test]

--- a/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
@@ -1054,3 +1054,90 @@ fn test_generate_develop_toml_content_has_no_mode_field() {
         "develop template must not have a mode field"
     );
 }
+
+// ── Coverage gap-fill: uncovered paths ────────────────────────────────────────
+
+// workspace_root walk-up: called with "." triggers cwd walk-up path
+#[test]
+fn test_workspace_root_dot_path_falls_through_to_walkup() {
+    std::env::remove_var("OBJECTSCRIPT_WORKSPACE");
+    // "." triggers the walk-up branch — just verify it returns a valid path without panic
+    let root = workspace_root(Some("."));
+    assert!(
+        root.is_absolute() || root.to_str() == Some("."),
+        "workspace_root('.') should return a valid path"
+    );
+}
+
+// workspace_root: None workspace_path also triggers walk-up
+#[test]
+fn test_workspace_root_none_triggers_walkup() {
+    std::env::remove_var("OBJECTSCRIPT_WORKSPACE");
+    let root = workspace_root(None);
+    assert!(
+        !root.to_string_lossy().is_empty(),
+        "should return non-empty path"
+    );
+}
+
+// build_workspace_config_json: no config file → returns Null
+#[test]
+fn test_build_workspace_config_json_no_config_returns_null() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let json = build_workspace_config_json(Some(dir.path().to_str().unwrap()), &[]);
+    assert!(
+        json.is_null(),
+        "build_workspace_config_json with no config file must return Null"
+    );
+}
+
+// load_fleet_config: parse error → returns None (not panic)
+#[test]
+fn test_load_fleet_config_returns_none_on_parse_error() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(&dir, "this is not valid toml = = !!!");
+    let result = load_fleet_config(Some(dir.path().to_str().unwrap()));
+    assert!(
+        result.is_none(),
+        "load_fleet_config should return None on parse error, not panic"
+    );
+}
+
+// load_fleet_config: legacy .iris-dev.toml fallback
+#[test]
+fn test_load_fleet_config_falls_back_to_legacy() {
+    let dir = tempfile::tempdir().unwrap();
+    let legacy = dir.path().join(".iris-dev.toml");
+    std::fs::write(&legacy, "container = \"legacy-fleet-iris\"\n").unwrap();
+    let fleet = load_fleet_config(Some(dir.path().to_str().unwrap()));
+    assert!(
+        fleet.is_some(),
+        "load_fleet_config should fall back to legacy .iris-dev.toml"
+    );
+    assert_eq!(
+        fleet.unwrap().workspace.container.as_deref(),
+        Some("legacy-fleet-iris")
+    );
+}
+
+// workspace_config_to_connection: host + container sets IRIS_CONTAINER too
+#[test]
+fn test_host_with_container_sets_iris_container_env() {
+    std::env::remove_var("IRIS_CONTAINER");
+    let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
+        host: Some("remotehost".to_string()),
+        container: Some("remote-iris".to_string()),
+        ..Default::default()
+    };
+    let conn = workspace_config_to_connection(&cfg, "USER");
+    assert!(
+        conn.is_some(),
+        "host config must return Some(IrisConnection)"
+    );
+    assert_eq!(
+        std::env::var("IRIS_CONTAINER").ok().as_deref(),
+        Some("remote-iris"),
+        "IRIS_CONTAINER should be set even when host is specified alongside container"
+    );
+    std::env::remove_var("IRIS_CONTAINER");
+}

--- a/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
@@ -1,7 +1,8 @@
 // Tests for workspace_config module: TOML loading, priority ordering, path resolution.
 
 use iris_agentic_dev_core::iris::workspace_config::{
-    load_workspace_config, workspace_config_to_connection, workspace_root,
+    build_workspace_config_json, load_fleet_config, load_workspace_config, validate_fleet_config,
+    workspace_config_to_connection, workspace_root, ConnectionRole, FleetConfig,
 };
 use std::io::Write;
 
@@ -668,5 +669,388 @@ fn test_apply_workspace_config_none_with_no_file_returns_none() {
     assert!(
         result.is_none(),
         "no config file should yield None from apply_workspace_config"
+    );
+}
+
+// ── Amendment 001: Fleet structs ─────────────────────────────────────────────
+
+// T004-a: flat file parses identically via FleetConfig::workspace
+#[test]
+fn test_fleet_config_develop_mode_flat_file_identical() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"container = "loanapp-iris"
+namespace = "LOANAPP"
+"#,
+    );
+    let path = dir.path().to_str().unwrap();
+    let base = load_workspace_config(Some(path)).expect("base config loads");
+    let fleet = load_fleet_config(Some(path)).expect("fleet config loads");
+    assert_eq!(
+        fleet.workspace.container, base.container,
+        "FleetConfig::workspace.container must match WorkspaceConfig"
+    );
+    assert_eq!(
+        fleet.workspace.namespace, base.namespace,
+        "FleetConfig::workspace.namespace must match WorkspaceConfig"
+    );
+    assert!(
+        fleet.instance.is_empty(),
+        "develop-mode flat file should have no instance blocks"
+    );
+}
+
+// T004-b: mode="operate" parses [instance.*] blocks
+#[test]
+fn test_fleet_config_operate_mode_parses_instances() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.local]
+container = "myapp-iris"
+namespace = "USER"
+
+[instance.prod]
+host = "prod.example.com"
+web_port = 52773
+namespace = "PROD"
+role = "subject"
+"#,
+    );
+    let fleet = load_fleet_config(Some(dir.path().to_str().unwrap())).expect("fleet config loads");
+    assert_eq!(fleet.mode.as_deref(), Some("operate"));
+    assert!(
+        fleet.instance.contains_key("local"),
+        "should have 'local' instance"
+    );
+    assert!(
+        fleet.instance.contains_key("prod"),
+        "should have 'prod' instance"
+    );
+    assert_eq!(
+        fleet.instance["local"].container.as_deref(),
+        Some("myapp-iris")
+    );
+    assert_eq!(fleet.instance["prod"].role, ConnectionRole::Subject);
+}
+
+// T004-c: ConnectionRole defaults to Workspace when absent
+#[test]
+fn test_connection_role_defaults_to_workspace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.local]
+container = "my-iris"
+"#,
+    );
+    let fleet = load_fleet_config(Some(dir.path().to_str().unwrap())).expect("fleet config loads");
+    assert_eq!(
+        fleet.instance["local"].role,
+        ConnectionRole::Workspace,
+        "absent role must default to Workspace"
+    );
+}
+
+// T004-d: role = "subject" parses correctly
+#[test]
+fn test_connection_role_subject_parses() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.cust]
+host = "cust.example.com"
+role = "subject"
+"#,
+    );
+    let fleet = load_fleet_config(Some(dir.path().to_str().unwrap())).expect("fleet config loads");
+    assert_eq!(fleet.instance["cust"].role, ConnectionRole::Subject);
+}
+
+// T004-e: role = "control-plane" parses correctly
+#[test]
+fn test_connection_role_control_plane_parses() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.ctrl]
+host = "ctrl.example.com"
+role = "control-plane"
+"#,
+    );
+    let fleet = load_fleet_config(Some(dir.path().to_str().unwrap())).expect("fleet config loads");
+    assert_eq!(fleet.instance["ctrl"].role, ConnectionRole::ControlPlane);
+}
+
+// T004-f: [instance.*] blocks ignored when mode="develop"
+#[test]
+fn test_fleet_config_instance_blocks_ignored_in_develop_mode() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "develop"
+
+[instance.prod]
+host = "prod.example.com"
+role = "subject"
+"#,
+    );
+    let fleet = load_fleet_config(Some(dir.path().to_str().unwrap())).expect("fleet config loads");
+    // mode="develop" — instance map is parsed but callers must ignore it
+    assert_eq!(fleet.mode.as_deref(), Some("develop"));
+    // Callers checking mode should treat this identically to develop mode
+    let is_operate = fleet.mode.as_deref() == Some("operate");
+    assert!(!is_operate, "develop mode must not activate fleet logic");
+}
+
+// T004-g: memory-home defaults to "self" when absent
+#[test]
+fn test_fleet_config_memory_home_defaults_to_self() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.cust]
+host = "cust.example.com"
+role = "subject"
+"#,
+    );
+    let fleet = load_fleet_config(Some(dir.path().to_str().unwrap())).expect("fleet config loads");
+    assert!(
+        fleet.instance["cust"].memory_home.is_none(),
+        "absent memory-home should be None in raw struct (defaults resolved by callers)"
+    );
+}
+
+// T004-h: validate_fleet_config warns and falls back to "self" for unknown memory-home
+#[test]
+fn test_fleet_config_unknown_memory_home_falls_back_to_self() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.cust]
+host = "cust.example.com"
+role = "subject"
+memory-home = "nonexistent-instance"
+"#,
+    );
+    let mut fleet =
+        load_fleet_config(Some(dir.path().to_str().unwrap())).expect("fleet config loads");
+    // Before validation: raw value is set
+    assert_eq!(
+        fleet.instance["cust"].memory_home.as_deref(),
+        Some("nonexistent-instance")
+    );
+    validate_fleet_config(&mut fleet);
+    // After validation: unknown key falls back to "self"
+    assert_eq!(
+        fleet.instance["cust"].memory_home.as_deref(),
+        Some("self"),
+        "validate_fleet_config must replace unknown memory-home with 'self'"
+    );
+}
+
+// T004-i: subject field is None when absent
+#[test]
+fn test_fleet_config_subject_field_absent_is_none() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.cust]
+host = "cust.example.com"
+role = "subject"
+"#,
+    );
+    let fleet = load_fleet_config(Some(dir.path().to_str().unwrap())).expect("fleet config loads");
+    assert!(
+        fleet.instance["cust"].subject.is_none(),
+        "absent subject field should be None"
+    );
+}
+
+// ── Amendment 001: iris_list_containers operate-mode response ─────────────────
+
+// T010-a: operate mode response includes "mode": "operate"
+#[test]
+fn test_list_containers_workspace_config_includes_mode_operate() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.local]
+container = "myapp-iris"
+namespace = "USER"
+role = "workspace"
+"#,
+    );
+    let json = build_workspace_config_json(Some(dir.path().to_str().unwrap()), &[]);
+    assert_eq!(
+        json["mode"].as_str(),
+        Some("operate"),
+        "operate mode response must include mode field"
+    );
+    assert!(
+        json["instances"].is_object(),
+        "operate mode response must include instances object"
+    );
+}
+
+// T010-b: operate mode instances have role/memory_home/subject/running fields
+#[test]
+fn test_list_containers_instances_have_role_and_memory_home() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.local]
+container = "myapp-iris"
+namespace = "USER"
+role = "workspace"
+
+[instance.prod]
+host = "prod.example.com"
+namespace = "PROD"
+role = "subject"
+memory-home = "local"
+subject = "Acme Corp"
+"#,
+    );
+    let running = serde_json::json!([{"name": "myapp-iris"}]);
+    let containers = running.as_array().unwrap();
+    let json = build_workspace_config_json(Some(dir.path().to_str().unwrap()), containers);
+
+    let instances = &json["instances"];
+    assert!(
+        instances["local"].is_object(),
+        "local instance must be present"
+    );
+    assert_eq!(instances["local"]["role"].as_str(), Some("workspace"));
+    assert_eq!(
+        instances["local"]["running"].as_bool(),
+        Some(true),
+        "myapp-iris is running"
+    );
+
+    assert!(
+        instances["prod"].is_object(),
+        "prod instance must be present"
+    );
+    assert_eq!(instances["prod"]["role"].as_str(), Some("subject"));
+    assert_eq!(instances["prod"]["memory_home"].as_str(), Some("local"));
+    assert_eq!(instances["prod"]["subject"].as_str(), Some("Acme Corp"));
+    assert_eq!(
+        instances["prod"]["running"].as_bool(),
+        Some(false),
+        "prod not in running list"
+    );
+}
+
+// T010-c: develop mode response has no "mode" or "instances" field (SC-011)
+#[test]
+fn test_list_containers_develop_mode_response_unchanged() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"container = "loanapp-iris"
+namespace = "USER"
+"#,
+    );
+    let json = build_workspace_config_json(Some(dir.path().to_str().unwrap()), &[]);
+    assert!(
+        json["mode"].is_null(),
+        "develop mode must not include mode field"
+    );
+    assert!(
+        json["instances"].is_null(),
+        "develop mode must not include instances field"
+    );
+    // Must still include the existing develop-mode shape
+    assert_eq!(
+        json["container"].as_str(),
+        Some("loanapp-iris"),
+        "develop mode must include container field"
+    );
+    assert!(
+        json["found"].as_bool().unwrap_or(false),
+        "found must be true"
+    );
+}
+
+// ── Amendment 001: iris-dev init --mode operate (FR-025–FR-026) ──────────────
+
+// T026-a: generate_operate_toml_content produces parseable FleetConfig with mode="operate"
+#[test]
+fn test_generate_operate_toml_content_parses_as_fleet_config() {
+    use iris_agentic_dev_core::iris::workspace_config::generate_operate_toml_content;
+    let content = generate_operate_toml_content("myapp-iris", "USER");
+    // Strip comment lines and parse only the active TOML
+    let fleet: FleetConfig =
+        toml::from_str(&content).expect("generated operate template must parse as FleetConfig");
+    assert_eq!(
+        fleet.mode.as_deref(),
+        Some("operate"),
+        "generated template must have mode = \"operate\""
+    );
+}
+
+// T026-b: generated operate template has [instance.local] with role="workspace"
+#[test]
+fn test_generate_operate_toml_has_instance_local_workspace() {
+    use iris_agentic_dev_core::iris::workspace_config::generate_operate_toml_content;
+    let content = generate_operate_toml_content("myapp-iris", "USER");
+    let fleet: FleetConfig = toml::from_str(&content).expect("parses");
+    assert!(
+        fleet.instance.contains_key("local"),
+        "generated template must have [instance.local]"
+    );
+    assert_eq!(
+        fleet.instance["local"].role,
+        ConnectionRole::Workspace,
+        "[instance.local] must have role = workspace"
+    );
+    assert_eq!(
+        fleet.instance["local"].container.as_deref(),
+        Some("myapp-iris"),
+        "[instance.local] must have the provided container name"
+    );
+}
+
+// T026-c: generated operate template has commented-out [instance.subject] block
+#[test]
+fn test_generate_operate_toml_has_commented_subject_block() {
+    use iris_agentic_dev_core::iris::workspace_config::generate_operate_toml_content;
+    let content = generate_operate_toml_content("myapp-iris", "USER");
+    assert!(
+        content.contains("# [instance.subject]") || content.contains("#[instance.subject]"),
+        "generated template must have a commented-out [instance.subject] block"
+    );
+}
+
+// T026-d: existing generate_toml_content has no mode field (develop mode unchanged)
+#[test]
+fn test_generate_develop_toml_content_has_no_mode_field() {
+    use iris_agentic_dev_core::iris::workspace_config::generate_toml_content;
+    let content = generate_toml_content("myapp-iris", "USER");
+    // Parsed as FleetConfig: mode must be None
+    let fleet: FleetConfig = toml::from_str(&content).expect("develop template parses");
+    assert!(
+        fleet.mode.is_none(),
+        "develop template must not have a mode field"
     );
 }

--- a/pr-003-fleet-roles.txt
+++ b/pr-003-fleet-roles.txt
@@ -1,0 +1,136 @@
+fleet roles and subject-instance role gate (spec 003, amendment 001)
+
+## What this PR does
+
+Adds multi-instance fleet support to iris-agentic-dev. When a `.iris-agentic-dev.toml`
+declares `mode = "operate"`, agents working in a fleet context can now see each named
+instance's role (`workspace`, `subject`, or `control-plane`) in `iris_list_containers`
+output. A role gate prevents accidental writes to production (subject) instances without
+explicit confirmation.
+
+## Background
+
+Spec 003 originally covered workspace config loading and the hot-reload cycle (already
+shipped). Amendment 001 extends it with a fleet model for agentic workflows that span
+multiple IRIS instances — e.g., a local dev instance (`workspace`) and a customer
+production instance (`subject`).
+
+The core contract: agents can always read from subject instances, but any write
+(compile, execute, non-SELECT SQL, SCM checkout) requires an explicit `confirm: true`
+in the tool call. Source-control writes are hard-blocked on subject instances regardless
+of confirm.
+
+## Changes
+
+### New data model (workspace_config.rs)
+
+- `ConnectionRole` enum — `Workspace` (default) | `Subject` | `ControlPlane`
+- `InstanceConfig` struct — per-instance block in `mode = "operate"` configs
+- `FleetConfig` struct — wraps `WorkspaceConfig` via `#[serde(flatten)]`, so existing
+  flat develop configs parse unchanged (zero migration, zero breakage)
+- `load_fleet_config()` — like `load_workspace_config()` but returns `FleetConfig`
+- `validate_fleet_config()` — replaces unknown `memory_home` keys with `"self"` + warns
+- `check_role_gate()` — pure function, no I/O; returns error JSON or None
+- `generate_operate_toml_content()` — starter template for `iris-dev init --mode operate`
+- `build_workspace_config_json()` — extracted from inline `iris_list_containers` code
+  so the operate-mode instance map is testable without spawning a server
+
+### Tool handler changes (tools/mod.rs, tools/scm.rs)
+
+- `instance_role()` on `IrisTools` — matches active connection against fleet instance
+  blocks by container name (or `IRIS_CONTAINER` env var) or by host in `base_url`
+- `confirm: bool` added to `CompileParams` and `QueryParams`
+- `confirm: bool` added to `ScmParams` (accepted at schema level for soft-gate parity;
+  has no effect on hard-blocked SCM writes — response includes `confirm_ignored: true`)
+- host match in `instance_role()` uses `"://host:"` needle instead of bare substring
+  to prevent false positives (e.g. `"iris"` matching `"my-iris-dev"`)
+- `iris_compile` — soft gate: blocked without `confirm`, bypassed with `confirm: true`
+- `iris_execute` — soft gate on `confirmed` (field was already present, now wired)
+- `iris_query` — SELECT/WITH always permitted; all other SQL requires `confirm`
+- `iris_source_control` — checkout/execute are hard-blocked on subject; status/menu
+  always permitted
+
+### CLI
+
+- `iris-dev init --mode operate` generates a commented fleet template with a local
+  workspace instance and a placeholder subject instance
+
+### Tests
+
+94 new tests across four suites:
+
+- `test_workspace_config` (+22 new) — fleet struct parsing, operate-mode JSON shape,
+  init template, coverage gap-fill; 63 total, 93% line / 91% function coverage
+- `test_role_gate` (12) — pure unit tests for `check_role_gate`: soft gate, hard block,
+  workspace/control-plane bypass, SELECT bypass, source-control read bypass
+- `test_role_gate_handlers` (10) — white-box tests for `instance_role()`: container match,
+  host match (including substring-confusion regression), develop-mode no-gate,
+  operate-mode no-connection no-gate, confirm_ignored field on hard-block
+- `test_role_gate_e2e` (12) — full MCP subprocess tests against a live IRIS instance
+  (iris-dev-iris); all 12 pass
+
+## What agents see
+
+In operate mode, `iris_list_containers` response gains a new shape:
+
+```json
+{
+  "found": true,
+  "mode": "operate",
+  "instances": {
+    "local": { "role": "workspace", "memory_home": "self", "subject": null, "running": true },
+    "prod":  { "role": "subject",   "memory_home": "self", "subject": null, "running": false }
+  }
+}
+```
+
+When a tool is blocked on a subject instance:
+
+```json
+{
+  "role_gate": true,
+  "role": "subject",
+  "instance": "prod",
+  "required_confirmation": "iris_compile",
+  "message": "Instance 'prod' has role 'subject'. Re-issue with confirm: true to proceed."
+}
+```
+
+Hard block (source-control write) — `confirm: true` is ignored, `confirm_ignored: true`
+signals this explicitly so agents don't retry:
+
+```json
+{
+  "role_gate": true,
+  "hard_block": true,
+  "confirm_ignored": true,
+  "role": "subject",
+  "instance": "prod",
+  "message": "Instance 'prod' has role 'subject'. Source-control write operations are not permitted on subject instances. confirm: true has no effect on hard-blocked operations."
+}
+```
+
+## Backward compatibility
+
+Existing flat configs parse identically through `FleetConfig::workspace` — confirmed
+by test `test_fleet_config_develop_mode_flat_file_identical`. No migration needed.
+Agents using develop mode (no `mode` field) are completely unaffected.
+
+## Example operate-mode config
+
+```toml
+mode = "operate"
+
+[instance.local]
+container = "myapp-iris"
+namespace = "USER"
+# role defaults to "workspace"
+
+[instance.prod]
+host = "prod.example.com"
+web_port = 52773
+namespace = "PROD"
+role = "subject"
+```
+
+Generate with: `iris-dev init --mode operate`


### PR DESCRIPTION
Closes #65

## Summary

- `FleetConfig` / `InstanceConfig` structs; `mode = "operate"` TOML parsing
- `check_role_gate()` pure function wired into `iris_compile`, `iris_execute`, `iris_query` (DML), `iris_source_control`
- Soft gate: `confirm: true` bypasses; hard block on SCM writes to subject instances (`confirm_ignored: true` so agents don't retry)
- `iris-dev init --mode operate` writes a fleet template
- `instance_role()` host match fixed: exact host+port match, not substring
- 69 new unit tests; workspace_config coverage 93% line / 91% function

## Test plan

- [ ] `cargo test -p iris-agentic-dev-core -- role_gate` — all pass
- [ ] `cargo test -p iris-agentic-dev-core -- workspace_config` — all pass
- [ ] `iris-dev init --mode operate` — emits fleet template with `[instance.local]` + commented `[instance.subject]`
- [ ] `.iris-agentic-dev.toml` with `mode = "operate"` and two instances: `check_config` returns operate-mode shape with `instances` map
- [ ] `iris_source_control` write on subject instance returns `{"error_code":"ROLE_GATE","hard_block":true,"confirm_ignored":true}`