### PR TITLE
Propositions on bugfixes and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,162 @@ or invoke the Linux binary via `wsl.exe`:
 
 ---
 
+## Connecting to IRIS
+
+### Native IRIS on Windows or Linux (no Docker)
+
+Add a `.iris-agentic-dev.toml` file to your project root:
+
+```toml
+host = "localhost"
+web_port = 80        # IIS default for IRIS 2024.1+; use 52773 for pre-2024.1
+namespace = "USER"
+username = "_SYSTEM"
+password = "SYS"
+```
+
+#### Port reference
+
+| IRIS version | Web server | Default port |
+|---|---|---|
+| 2024.1+ on Windows | IIS | 80 |
+| 2024.1+ on Linux | Apache | 80 |
+| Pre-2024.1 (any OS) | Private Web Server (PWS) | 52773 |
+
+#### Windows IIS: `/api` web application required
+
+This is the most common failure on Windows. IIS needs an explicit `/api` web application mapped to the IRIS Web Gateway module. Without it, `/api/atelier` returns 404 — even when the Management Portal loads correctly.
+
+**To fix:**
+
+1. Open **IIS Manager** → expand your server → **Sites** → **Default Web Site**
+2. Right-click → **Add Application**. Set alias: `api`, physical path: `C:\InterSystems\IRIS\CSP\bin` (adjust to your install path)
+3. Add a wildcard script handler mapping: executable = `CSPms.dll`, no verb restriction
+4. Verify `CSP.ini` contains an `[APP_PATH:/api]` section
+
+See the [`iris-windows-iis-setup` skill](./light-skills/skills/iris-windows-iis-setup/SKILL.md) for full step-by-step instructions with verification commands.
+
+**`localhost` vs `127.0.0.1`**: On some older Web Gateway builds, using `localhost` causes a brief connection error before each request. If you see connection delays, change the config to `host = "127.0.0.1"`.
+
+### Docker (community image)
+
+Run `iris-agentic-dev init` in your project directory — it detects any running IRIS containers and writes `.iris-agentic-dev.toml` automatically:
+
+```bash
+iris-agentic-dev init
+```
+
+Or configure manually:
+
+```toml
+container = "myapp-iris"
+namespace = "MYAPP"
+```
+
+### Docker (enterprise image)
+
+Enterprise IRIS images (`intersystems/iris`, `intersystems/irishealth`) ship without a built-in web server. Run the ISC Web Gateway container alongside IRIS:
+
+```yaml
+services:
+  iris:
+    image: containers.intersystems.com/intersystems/iris:2026.1
+    ports: ["4972:1972"]
+  webgateway:
+    image: containers.intersystems.com/intersystems/webgateway:2026.1
+    ports: ["52773:80"]
+    entrypoint: ["/bin/sh", "/init.sh"]
+    volumes: ["./webgateway-init.sh:/init.sh:ro"]
+```
+
+See the [`iris-vscode-objectscript` skill](./light-skills/skills/iris-vscode-objectscript/SKILL.md) for a working `webgateway-init.sh`.
+
+### VS Code Server Manager (zero-config)
+
+If the [InterSystems Server Manager](https://marketplace.visualstudio.com/items?itemName=intersystems-community.servermanager) extension is installed, iris-agentic-dev reads your server list from VS Code's `settings.json` and resolves credentials from the OS keychain automatically — no `.iris-agentic-dev.toml` needed.
+
+**Single server configured:** auto-connects, no extra setup.
+
+**Multiple servers configured:** set `IRIS_SERVER_NAME` to the map key from `intersystems.servers`:
+
+```bash
+export IRIS_SERVER_NAME=dev-local
+```
+
+Credentials are stored under keychain service `"intersystems-server-credentials"` — the auth provider ID used by Server Manager in all VS Code-compatible forks (Cursor, Windsurf, VS Code Insiders). If a credential is missing, iris-agentic-dev fails fast with a message directing you to reconnect in VS Code (right-click the server → **Reconnect**) rather than silently falling through to other discovery sources.
+
+Use `check_config` to see which servers were detected and whether credentials resolved:
+
+```json
+{
+  "server_manager": {
+    "available": true,
+    "servers": [
+      { "name": "dev-local", "active": true, "credential_status": "resolved" }
+    ]
+  }
+}
+```
+
+### Per-connection policy (fleet / operate mode)
+
+Add `[policy.<server-name>]` blocks to `.iris-agentic-dev.toml` to restrict which tool categories are permitted on a given Server Manager server:
+
+```toml
+[policy.prod]
+allow = ["query", "search", "docs"]
+```
+
+Blocked calls return `error_code: "POLICY_GATE"` with the list of allowed categories. Omit the block entirely to permit everything. Available categories: `compile`, `execute`, `query`, `search`, `docs`, `source_control`, `debug`, `admin`, `skill`, `kb`.
+
+For multi-instance fleet workflows (`mode = "operate"`), see the [fleet roles spec](./specs/003-workspace-config/) for the full `[instance.*]` config format and role-gate behavior.
+
+### Connection discovery order
+
+iris-agentic-dev resolves the IRIS connection in this order — first match wins:
+
+1. CLI flags (`--host`, `--web-port`, `--scheme`)
+2. `.iris-agentic-dev.toml` in the workspace root
+3. Environment variables (`IRIS_HOST`, etc.)
+4. VS Code `settings.json` (`objectscript.conn` / `intersystems.servers`)
+5. VS Code Server Manager keychain (`intersystems.servers` + OS keychain credential)
+6. Running Docker containers (scored by workspace name similarity)
+7. Localhost port scan (52773, 41773, 51773, 8080)
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IRIS_HOST` | `localhost` | IRIS web gateway hostname |
+| `IRIS_WEB_PORT` | `52773` | Web gateway port |
+| `IRIS_SCHEME` | `http` | `http` or `https` |
+| `IRIS_WEB_PREFIX` | *(empty)* | URL path prefix for non-root gateway installs |
+| `IRIS_USERNAME` | `_SYSTEM` | IRIS username |
+| `IRIS_PASSWORD` | `SYS` | IRIS password |
+| `IRIS_SERVICE_USERNAME` | *(empty)* | Restricted service account for arbitrary-execution tools (see below) |
+| `IRIS_SERVICE_PASSWORD` | *(empty)* | Password for `IRIS_SERVICE_USERNAME` |
+| `IRIS_NAMESPACE` | `USER` | Default namespace |
+| `IRIS_CONTAINER` | *(empty)* | Docker container name — required for Docker-dependent tools |
+| `IRIS_SERVER_NAME` | *(empty)* | Server Manager server name when multiple are configured |
+| `OBJECTSCRIPT_WORKSPACE` | `$PWD` | Workspace root for `.iris-agentic-dev.toml` lookup |
+
+### Privilege separation for arbitrary execution
+
+`iris_execute`, `iris_execute_method`, `iris_query` (`mode="write"`), and `iris_global`
+(`set`/`kill`) can run arbitrary ObjectScript/SQL. Under a `%All` account these can edit class
+and routine code — even by indirection (`$classmethod`, `$method("%Sa"_"ve")`, `xecute`) —
+bypassing the SCM lock and the `CODE_EDIT_BLOCKED` string filter, since no static text filter
+can be exhaustive against a fully-privileged identity.
+
+Set `IRIS_SERVICE_USERNAME` / `IRIS_SERVICE_PASSWORD` to a **least-privilege** IRIS account
+(no `%Development` resource, code database mounted read-only). Those four tools then authenticate
+as that account, so code edits fail with `<PROTECT>` at the IRIS privilege layer regardless of
+indirection. Code-writing tools (`iris_document` put, `iris_source_control`, `iris_compile`)
+deliberately keep using the primary `IRIS_USERNAME`, so SCM checkouts and audit stay attributed
+to the real user. When unset, all tools use the primary connection (unchanged behaviour).
+
+---
+
 ## Skills — improve AI output for ObjectScript
 
 Skills are concise instruction files that teach your AI assistant ObjectScript patterns and

--- a/crates/iris-agentic-dev-core/src/iris/connection.rs
+++ b/crates/iris-agentic-dev-core/src/iris/connection.rs
@@ -450,10 +450,6 @@ impl IrisConnection {
             // A residual like <ENDOFFILE> is often left as a benign side effect of an
             // SCM provider's internal Read even when the operation fully succeeded;
             // appending it to a non-empty result corrupted otherwise-valid output.
-            // Only surface a non-exception $ZERROR when the body produced NO output.
-            // A residual like <ENDOFFILE> is often left as a benign side effect of an
-            // SCM provider's internal Read even when the operation fully succeeded;
-            // appending it to a non-empty result corrupted otherwise-valid output.
             "  If (out=\"\") && (ze'=\"\") && (ze'=\",\") { Set out = \"ERROR($ZERROR): \"_ze_$Char(10) }"
                 .into(),
             "  Quit out".into(),

--- a/crates/iris-agentic-dev-core/src/tools/scm.rs
+++ b/crates/iris-agentic-dev-core/src/tools/scm.rs
@@ -482,16 +482,10 @@ fn derive_scm_status(
     let owner_opt = Some(owner.trim().to_string()).filter(|s| !s.is_empty());
     let any_signal =
         is_in_sc || has_checkout || has_undo_checkout || has_add_to_sc || owner_opt.is_some();
-    // No signal at all → no SCM configured, document is freely editable.
-    // (GetStatus errors with empty menus also land here — treat as uncontrolled.)
+    // No signal at all → we genuinely don't know. Reporting "editable: true" here is the exact
+    // false-positive this rewrite eliminates (GetStatus errors and empty menus both land here).
     if !any_signal {
-        return Some(ScmStatus {
-            controlled: false,
-            editable: true,
-            locked: false,
-            checked_out_by_me: false,
-            owner: None,
-        });
+        return None;
     }
 
     // A document is uncontrolled iff we are offered the action to add it to source control.
@@ -558,19 +552,13 @@ fn parse_scm_status_line(line: &str) -> Option<(bool, bool, bool, bool, String)>
     let has_undo_checkout = flag(parts.next())?;
     let has_add_to_sc = flag(parts.next())?;
     let owner = parts.next().unwrap_or("").trim().to_string();
-    Some((
-        is_in_sc,
-        has_checkout,
-        has_undo_checkout,
-        has_add_to_sc,
-        owner,
-    ))
+    Some((is_in_sc, has_checkout, has_undo_checkout, has_add_to_sc, owner))
 }
 
 /// Fallback owner detection from the SCM provider's native `checked out by user '<name>'` notice.
 ///
 /// Some source-control providers emit a native `NOTICE: … is currently checked out by user
-/// 'todor', and was last updated at 2026-07-07 12:34:56` message (often followed by a `<PROTECT>`)
+/// 'xxx', and was last updated at 2026-07-07 12:34:56` message (often followed by a `<PROTECT>`)
 /// that short-circuits `status_check_code` before the `SCMSTATUS|` sentinel is ever written. In
 /// that case `parse_scm_status_line` finds nothing, yet the raw output already tells us the
 /// document is controlled and locked by another user — so we scrape it here instead of reporting
@@ -583,9 +571,11 @@ fn parse_checked_out_by(raw: &str) -> Option<(String, Option<String>)> {
     use std::sync::OnceLock;
     static RE: OnceLock<regex::Regex> = OnceLock::new();
     let re = RE.get_or_init(|| {
-        // "checked out by user 'todor'" — timestamp captured only if the line isn't truncated.
-        regex::Regex::new(r"checked out by user '([^']+)'(?:.*?updated at ([0-9-]+ [0-9:]+))?")
-            .expect("static SCM checked-out regex is valid")
+        // "checked out by user 'xxx'" — timestamp captured only if the line isn't truncated.
+        regex::Regex::new(
+            r"checked out by user '([^']+)'(?:.*?updated at ([0-9-]+ [0-9:]+))?",
+        )
+        .expect("static SCM checked-out regex is valid")
     });
     let caps = re.captures(raw)?;
     let owner = caps.get(1)?.as_str().trim().to_string();
@@ -1038,16 +1028,10 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_no_signal_is_uncontrolled() {
-        // No in-SC flag, no menu items, no owner → no SCM configured in this namespace.
-        // Must return controlled:false, editable:true — NOT None/SCM_UNAVAILABLE, which
-        // was a false-positive error for namespaces that simply have no SCM.
-        let s = derive_scm_status(false, false, false, false, "", "me").unwrap();
-        assert!(!s.controlled);
-        assert!(s.editable);
-        assert!(!s.locked);
-        assert!(!s.checked_out_by_me);
-        assert!(s.owner.is_none());
+    fn test_derive_no_signal_is_indeterminate() {
+        // No in-SC flag, no menu items, no owner → indeterminate → None (caller reports
+        // SCM_UNAVAILABLE), never a false "editable: true".
+        assert!(derive_scm_status(false, false, false, false, "", "me").is_none());
     }
 
     #[test]


### PR DESCRIPTION
This PR should not be merged any time soon since it includes breaking changes, 
This aims to provide code and ideas of bug fixes:

Features
  - Code-edit gate: block code changes via iris_execute / iris_query write (%Dictionary, $system.OBJ, code globals)
  - Restricted service-account routing for privileged tools (IRIS_SERVICE_USERNAME/PASSWORD, isolated cookie jar)
  - iris_doc insert mode (splice content at a line)
  - iris_doc delete_lines mode (remove a line range)
  - Stale-edit guard via expected param (STALE_CONTENT)
  - Edit responses return re-numbered post-write content
  - Centralized elicitation resume for all write paths
  - Search requires a document scope (SCOPE_REQUIRED)
  - Configurable search sync timeout (IRIS_SEARCH_SYNC_TIMEOUT, default 30s)
 
  Bug fixes
  - Search response parsing: v8 array shape, nested matches, count matches not docs
  - Search case sensitivity: always send case flag (default insensitive)
  - SCM status no longer false-positives as editable
  - SCM owner detection from native "checked out by" notice
  - Checkout finalized via AfterUserAction (fixes ERROR #5865)
  - Block CheckIn in SCM tool -> this is not configurable, i did it because i wanted it for me but if you want it maybe i can provide an argument --prevent-checkin on the mcp server
  - iris_doc delete checks status.errors (no false success on locked docs)
  - Empty-name guards return MISSING_PARAMS instead of cryptic #16006
  - Lenient integer deserialization (accept "214" as string)
  - mode field as plain string, not enum $ref (fixes empty tool-call args)
  - Executor $ZERROR/<ENDOFFILE> output corruption fix
  - Broader connection retry classification
  - DOCKER_REQUIRED replaced with HTTP_EXECUTION_FAILED when appropriate
 