### PR TITLE
Fix/vscode mask password in logs

### DIFF
--- a/vscode-iris-agentic-dev/.gitignore
+++ b/vscode-iris-agentic-dev/.gitignore
@@ -1,3 +1,4 @@
 out/
+.test-out/
 node_modules/
 *.vsix

--- a/vscode-iris-agentic-dev/package.json
+++ b/vscode-iris-agentic-dev/package.json
@@ -85,6 +85,7 @@
   },
   "scripts": {
     "compile": "esbuild src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
+    "test": "esbuild src/redact.ts --bundle --outfile=.test-out/redact.cjs --format=cjs --platform=node && node --test test/redact.test.cjs",
     "package": "npm run compile && vsce package --no-dependencies"
   },
   "dependencies": {

--- a/vscode-iris-agentic-dev/src/extension.ts
+++ b/vscode-iris-agentic-dev/src/extension.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import which from 'which';
 import * as serverManager from '@intersystems-community/intersystems-servermanager';
+import { stringifyForLog } from './redact';
 
 function findIrisDev(): string | null {
   const cfg = vscode.workspace.getConfiguration('iris-agentic-dev');
@@ -87,7 +88,7 @@ export class IrisDevMcpProvider
       .getConfiguration('objectscript', wsFolder ?? null)
       .get<ObjectScriptConn>('conn');
 
-    this.log.info(`iris-agentic-dev: objectscript.conn = ${JSON.stringify(conn)}`);
+    this.log.info(`iris-agentic-dev: objectscript.conn = ${stringifyForLog(conn)}`);
 
     if (!conn || conn.active === false) {
       this.log.warn('iris-agentic-dev: ObjectScript connection is not configured or inactive');
@@ -152,7 +153,7 @@ export class IrisDevMcpProvider
         return [];
       }
       named = servers[conn.server];
-      this.log.info(`iris-agentic-dev: named server resolved = ${JSON.stringify(named)}`);
+      this.log.info(`iris-agentic-dev: named server resolved = ${stringifyForLog(named)}`);
     }
 
     const host = conn.host ?? 'localhost';
@@ -195,7 +196,7 @@ export class IrisDevMcpProvider
     ) as Record<string, string | number>;
 
     this.log.info(`iris-agentic-dev: scheme=${webScheme ?? 'http'} prefix=${webPrefix ?? '(none)'}`);
-    this.log.info(`iris-agentic-dev: launching binary with env = ${JSON.stringify(env)}`);
+    this.log.info(`iris-agentic-dev: launching binary with env = ${stringifyForLog(env)}`);
 
     const definition = new vscode.McpStdioServerDefinition(
       'iris-agentic-dev (IRIS)',

--- a/vscode-iris-agentic-dev/src/redact.ts
+++ b/vscode-iris-agentic-dev/src/redact.ts
@@ -1,4 +1,4 @@
-const REDACTED = '[REDACTED]';
+const MASK = '********';
 
 // Match credential-bearing field names used by VS Code, Server Manager, and
 // process environments. Keeping this key-based avoids altering benign values.
@@ -14,7 +14,7 @@ export function redactSecrets(value: unknown): unknown {
     return Object.fromEntries(
       Object.entries(value).map(([key, nestedValue]) => [
         key,
-        SENSITIVE_KEY.test(key) ? REDACTED : redactSecrets(nestedValue),
+        SENSITIVE_KEY.test(key) ? MASK : redactSecrets(nestedValue),
       ])
     );
   }

--- a/vscode-iris-agentic-dev/src/redact.ts
+++ b/vscode-iris-agentic-dev/src/redact.ts
@@ -1,0 +1,27 @@
+const REDACTED = '[REDACTED]';
+
+// Match credential-bearing field names used by VS Code, Server Manager, and
+// process environments. Keeping this key-based avoids altering benign values.
+const SENSITIVE_KEY = /(?:password|passwd|passphrase|access[_-]?token|auth[_-]?token|api[_-]?key|secret)$/i;
+
+/** Return a log-safe copy of a value without modifying the original. */
+export function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactSecrets);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        SENSITIVE_KEY.test(key) ? REDACTED : redactSecrets(nestedValue),
+      ])
+    );
+  }
+
+  return value;
+}
+
+export function stringifyForLog(value: unknown): string {
+  return JSON.stringify(redactSecrets(value));
+}

--- a/vscode-iris-agentic-dev/test/redact.test.cjs
+++ b/vscode-iris-agentic-dev/test/redact.test.cjs
@@ -12,8 +12,8 @@ test('redacts password fields without changing the source object', () => {
 
   assert.deepEqual(redactSecrets(source), {
     username: 'SuperUser',
-    password: '[REDACTED]',
-    nested: { IRIS_PASSWORD: '[REDACTED]', host: 'localhost' },
+    password: '********',
+    nested: { IRIS_PASSWORD: '********', host: 'localhost' },
   });
   assert.equal(source.password, 'settings-secret');
   assert.equal(source.nested.IRIS_PASSWORD, 'SYS');
@@ -28,7 +28,7 @@ test('redacts related credential fields in nested objects and arrays', () => {
   assert.equal(logValue.includes('token-value'), false);
   assert.equal(logValue.includes('key-value'), false);
   assert.equal(logValue.includes('secret-value'), false);
-  assert.equal(logValue.includes('[REDACTED]'), true);
+  assert.equal(logValue.includes('********'), true);
 });
 
 test('keeps non-sensitive launch environment values visible', () => {

--- a/vscode-iris-agentic-dev/test/redact.test.cjs
+++ b/vscode-iris-agentic-dev/test/redact.test.cjs
@@ -1,0 +1,39 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { redactSecrets, stringifyForLog } = require('../.test-out/redact.cjs');
+
+test('redacts password fields without changing the source object', () => {
+  const source = {
+    username: 'SuperUser',
+    password: 'settings-secret',
+    nested: { IRIS_PASSWORD: 'SYS', host: 'localhost' },
+  };
+
+  assert.deepEqual(redactSecrets(source), {
+    username: 'SuperUser',
+    password: '[REDACTED]',
+    nested: { IRIS_PASSWORD: '[REDACTED]', host: 'localhost' },
+  });
+  assert.equal(source.password, 'settings-secret');
+  assert.equal(source.nested.IRIS_PASSWORD, 'SYS');
+});
+
+test('redacts related credential fields in nested objects and arrays', () => {
+  const logValue = stringifyForLog({
+    accessToken: 'token-value',
+    servers: [{ api_key: 'key-value', clientSecret: 'secret-value' }],
+  });
+
+  assert.equal(logValue.includes('token-value'), false);
+  assert.equal(logValue.includes('key-value'), false);
+  assert.equal(logValue.includes('secret-value'), false);
+  assert.equal(logValue.includes('[REDACTED]'), true);
+});
+
+test('keeps non-sensitive launch environment values visible', () => {
+  assert.equal(
+    stringifyForLog({ IRIS_HOST: 'localhost', IRIS_WEB_PORT: 8080 }),
+    '{"IRIS_HOST":"localhost","IRIS_WEB_PORT":8080}'
+  );
+});


### PR DESCRIPTION
## Summary

Mask credentials written to the VS Code output channel.

Password and other sensitive fields now appear as `********` in:

- `objectscript.conn` logs
- Named server configuration logs
- MCP process environment logs

The actual environment passed to the MCP server remains unchanged.

## Testing

- Added unit tests for nested credential redaction
- Verified source objects are not modified
- Verified extension compilation and TypeScript checks
- Tested non-sensitive environment values remain visible