### PR TITLE
fix(codegen): embed user strings into generated ObjectScript correctly

### DIFF
--- a/crates/iris-agentic-dev-core/src/lib.rs
+++ b/crates/iris-agentic-dev-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod benchmark;
 pub mod elicitation;
 pub mod iris;
 pub mod manifest;
+pub mod objectscript;
 pub mod policy;
 pub mod skill_install;
 pub mod skills;

--- a/crates/iris-agentic-dev-core/src/objectscript.rs
+++ b/crates/iris-agentic-dev-core/src/objectscript.rs
@@ -1,0 +1,136 @@
+//! Safe embedding of user-supplied strings into generated ObjectScript source.
+//!
+//! ObjectScript string literals have exactly one escape: a quote is doubled
+//! (`""`). Backslash is an ordinary character — C-style `\"` is a syntax error
+//! (the `\` stays literal and the `"` terminates the string). A literal cannot
+//! span source lines, and `build_exec_class` splits generated code on `\n`, so
+//! control characters must never appear inside a literal; they are spliced in
+//! via `$CHAR(n,...)` instead.
+
+/// Render `s` as a single-line ObjectScript *expression* that evaluates to
+/// exactly `s`: printable runs become quoted literals with `"` doubled,
+/// control characters become `$CHAR(n,...)` splices.
+///
+/// `os_str_expr(r#"say "hi""#)` → `"say ""hi"""`
+/// `os_str_expr("a\r\nb")` → `"a"_$CHAR(13,10)_"b"`
+pub fn os_str_expr(s: &str) -> String {
+    if s.is_empty() {
+        return "\"\"".into();
+    }
+    let mut parts: Vec<String> = Vec::new();
+    let mut lit = String::new();
+    let mut ctl: Vec<u32> = Vec::new();
+    let flush_lit = |lit: &mut String, parts: &mut Vec<String>| {
+        if !lit.is_empty() {
+            parts.push(format!("\"{}\"", lit.replace('"', "\"\"")));
+            lit.clear();
+        }
+    };
+    let flush_ctl = |ctl: &mut Vec<u32>, parts: &mut Vec<String>| {
+        if !ctl.is_empty() {
+            let codes: Vec<String> = ctl.iter().map(|c| c.to_string()).collect();
+            parts.push(format!("$CHAR({})", codes.join(",")));
+            ctl.clear();
+        }
+    };
+    for ch in s.chars() {
+        let code = ch as u32;
+        if code < 0x20 || code == 0x7f {
+            flush_lit(&mut lit, &mut parts);
+            ctl.push(code);
+        } else {
+            flush_ctl(&mut ctl, &mut parts);
+            lit.push(ch);
+        }
+    }
+    flush_lit(&mut lit, &mut parts);
+    flush_ctl(&mut ctl, &mut parts);
+    parts.join("_")
+}
+
+/// Statements that write `payload` to the open stream held in `stream_var`,
+/// chunked so no generated source line approaches the routine line-length
+/// limit (worst case a chunk of quotes doubles, plus `$CHAR` overhead).
+pub fn os_stream_write_stmts(stream_var: &str, payload: &str, chunk_chars: usize) -> Vec<String> {
+    let chars: Vec<char> = payload.chars().collect();
+    chars
+        .chunks(chunk_chars.max(1))
+        .map(|c| {
+            let piece: String = c.iter().collect();
+            format!("Do {}.Write({})", stream_var, os_str_expr(&piece))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_string_is_quoted() {
+        assert_eq!(os_str_expr("GeneroSOAP"), "\"GeneroSOAP\"");
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(os_str_expr(""), "\"\"");
+    }
+
+    #[test]
+    fn quotes_are_doubled_not_backslashed() {
+        assert_eq!(os_str_expr(r#"key="M""#), r#""key=""M""""#);
+        assert!(!os_str_expr(r#"a"b"#).contains('\\'));
+    }
+
+    #[test]
+    fn backslash_is_literal() {
+        assert_eq!(os_str_expr(r"C:\tmp"), "\"C:\\tmp\"");
+    }
+
+    #[test]
+    fn apostrophe_untouched() {
+        assert_eq!(os_str_expr("it's"), "\"it's\"");
+    }
+
+    #[test]
+    fn newlines_become_char_splices() {
+        assert_eq!(os_str_expr("a\nb"), "\"a\"_$CHAR(10)_\"b\"");
+        assert_eq!(os_str_expr("a\r\nb"), "\"a\"_$CHAR(13,10)_\"b\"");
+        assert_eq!(os_str_expr("\n"), "$CHAR(10)");
+    }
+
+    #[test]
+    fn unicode_passes_through() {
+        assert_eq!(os_str_expr("señal"), "\"señal\"");
+    }
+
+    #[test]
+    fn every_expr_line_has_balanced_quotes() {
+        let samples = [
+            "plain",
+            r#"<entry table="G" key="M">1</entry>"#,
+            "multi\nline\r\nwith\ttabs",
+            "quote\"and'apostrophe",
+        ];
+        for s in samples {
+            let expr = os_str_expr(s);
+            assert!(!expr.contains('\n'), "expr must be single-line: {expr}");
+            assert_eq!(
+                expr.matches('"').count() % 2,
+                0,
+                "unbalanced quotes in {expr}"
+            );
+        }
+    }
+
+    #[test]
+    fn write_stmts_chunk_and_cover_payload() {
+        let payload = "x".repeat(1000);
+        let stmts = os_stream_write_stmts("tStream", &payload, 400);
+        assert_eq!(stmts.len(), 3);
+        assert!(stmts.iter().all(|s| s.starts_with("Do tStream.Write(")));
+        // chunking must never split on a non-char boundary
+        let stmts = os_stream_write_stmts("tStream", &"ñ".repeat(401), 400);
+        assert_eq!(stmts.len(), 2);
+    }
+}

--- a/crates/iris-agentic-dev-core/src/tools/admin.rs
+++ b/crates/iris-agentic-dev-core/src/tools/admin.rs
@@ -3,6 +3,7 @@
 //! Read operations are always available; write operations require IRIS_ADMIN_TOOLS=1.
 
 use crate::iris::connection::IrisConnection;
+use crate::objectscript::os_str_expr;
 use rmcp::{model::*, ErrorData as McpError};
 
 fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
@@ -296,12 +297,11 @@ pub async fn admin_list_user_roles_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let un = username.replace('\'', "''");
+    let un = os_str_expr(username);
     let code = format!(
-        r#"Set tSC=##class(Security.Users).Get("{}",.props)
-If $$$ISERR(tSC) {{ Write "ERROR:USER_NOT_FOUND:User not found: {}" Quit }}
-Write $GET(props("Roles"))"#,
-        un, un
+        r#"Set tSC=##class(Security.Users).Get({un},.props)
+If $$$ISERR(tSC) {{ Write "ERROR:USER_NOT_FOUND:User not found: "_{un} Quit }}
+Write $GET(props("Roles"))"#
     );
     match iris.execute_via_generator(&code, "%SYS", &client).await {
         Ok(out) => {
@@ -331,16 +331,15 @@ pub async fn admin_get_webapp_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let p = path.replace('\'', "''");
+    let p = os_str_expr(path);
     let code = format!(
-        r#"Set tSC=##class(Security.Applications).Get("{}",.props)
-If $$$ISERR(tSC) {{ Write "ERROR:WEBAPP_NOT_FOUND:Webapp not found: {}" Quit }}
+        r#"Set tSC=##class(Security.Applications).Get({p},.props)
+If $$$ISERR(tSC) {{ Write "ERROR:WEBAPP_NOT_FOUND:Webapp not found: "_{p} Quit }}
 Set dc=$GET(props("DispatchClass"))
 Set ns=$GET(props("NameSpace"))
 Set en=$GET(props("Enabled"))
 Set tp=$SELECT(dc'="":"REST",1:"CSP")
-Write ns_"|"_dc_"|"_en_"|"_tp"#,
-        p, p
+Write ns_"|"_dc_"|"_en_"|"_tp"#
     );
     match iris.execute_via_generator(&code, "%SYS", &client).await {
         Ok(out) => {
@@ -387,11 +386,11 @@ pub async fn admin_check_permission_impl(
         "DELETE" | "D" => "D",
         other => other,
     };
-    let res = resource.replace('\'', "''");
-    let op_escaped = op.replace('\'', "''");
+    let res = os_str_expr(resource);
+    let op_escaped = os_str_expr(op);
     // %SYSTEM.Security.Check(ResourceName, Permissions) — documented IRIS API
     let code = format!(
-        r#"If ##class(%SYSTEM.Security).Check("{}","{}") {{ Write "GRANTED" }} Else {{ Write "DENIED" }}"#,
+        r#"If ##class(%SYSTEM.Security).Check({},{}) {{ Write "GRANTED" }} Else {{ Write "DENIED" }}"#,
         res, op_escaped
     );
     // Get the current username from env for reporting
@@ -428,17 +427,16 @@ pub async fn admin_create_user_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let un = username.replace('\'', "''");
-    let pw = password.replace('\'', "''");
-    let fn_ = full_name.unwrap_or("").replace('\'', "''");
-    let ro = roles.unwrap_or("").replace('\'', "''");
+    let un = os_str_expr(username);
+    let pw = os_str_expr(password);
+    let fn_ = os_str_expr(full_name.unwrap_or(""));
+    let ro = os_str_expr(roles.unwrap_or(""));
     let code = format!(
-        r#"Set props("Password")="{}"
-Set props("FullName")="{}"
-Set props("Roles")="{}"
-Set tSC=##class(Security.Users).Create("{}",.props)
-If $$$ISERR(tSC) {{ Write "ERROR:USER_EXISTS:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
-        pw, fn_, ro, un
+        r#"Set props("Password")={pw}
+Set props("FullName")={fn_}
+Set props("Roles")={ro}
+Set tSC=##class(Security.Users).Create({un},.props)
+If $$$ISERR(tSC) {{ Write "ERROR:USER_EXISTS:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#
     );
     match iris.execute_via_generator(&code, "%SYS", &client).await {
         Ok(out) => {
@@ -474,13 +472,10 @@ pub async fn admin_update_user_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let un = username.replace('\'', "''");
+    let un = os_str_expr(username);
     let mut set_lines = String::new();
     if let Some(pw) = password {
-        set_lines.push_str(&format!(
-            "Set props(\"Password\")=\"{}\"\n",
-            pw.replace('\'', "''")
-        ));
+        set_lines.push_str(&format!("Set props(\"Password\")={}\n", os_str_expr(pw)));
     }
     if let Some(en) = enabled {
         set_lines.push_str(&format!(
@@ -489,17 +484,13 @@ pub async fn admin_update_user_impl(
         ));
     }
     if let Some(ro) = roles {
-        set_lines.push_str(&format!(
-            "Set props(\"Roles\")=\"{}\"\n",
-            ro.replace('\'', "''")
-        ));
+        set_lines.push_str(&format!("Set props(\"Roles\")={}\n", os_str_expr(ro)));
     }
     let code = format!(
-        r#"Set tSC=##class(Security.Users).Get("{}",.props)
-If $$$ISERR(tSC) {{ Write "ERROR:USER_NOT_FOUND:User not found: {}" Quit }}
-{}Set tSC2=##class(Security.Users).Modify("{}",.props)
-If $$$ISERR(tSC2) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC2) }} Else {{ Write "OK" }}"#,
-        un, un, set_lines, un
+        r#"Set tSC=##class(Security.Users).Get({un},.props)
+If $$$ISERR(tSC) {{ Write "ERROR:USER_NOT_FOUND:User not found: "_{un} Quit }}
+{set_lines}Set tSC2=##class(Security.Users).Modify({un},.props)
+If $$$ISERR(tSC2) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC2) }} Else {{ Write "OK" }}"#
     );
     match iris.execute_via_generator(&code, "%SYS", &client).await {
         Ok(out) => {
@@ -532,12 +523,11 @@ pub async fn admin_delete_user_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let un = username.replace('\'', "''");
+    let un = os_str_expr(username);
     let code = format!(
-        r#"If '##class(Security.Users).Exists("{}") {{ Write "ERROR:USER_NOT_FOUND:User not found: {}" Quit }}
-Set tSC=##class(Security.Users).Delete("{}")
-If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
-        un, un, un
+        r#"If '##class(Security.Users).Exists({un}) {{ Write "ERROR:USER_NOT_FOUND:User not found: "_{un} Quit }}
+Set tSC=##class(Security.Users).Delete({un})
+If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#
     );
     match iris.execute_via_generator(&code, "%SYS", &client).await {
         Ok(out) => {
@@ -572,16 +562,15 @@ pub async fn admin_create_namespace_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let nm = name.replace('\'', "''");
-    let cd = code_database.replace('\'', "''");
-    let dd = data_database.replace('\'', "''");
+    let nm = os_str_expr(name);
+    let cd = os_str_expr(code_database);
+    let dd = os_str_expr(data_database);
     let code = format!(
-        r#"Set ns("Globals")="{}"
-Set ns("Routines")="{}"
-Set ns("Database")="{}"
-Set tSC=##class(Config.Namespaces).Create("{}",.ns)
-If $$$ISERR(tSC) {{ Write "ERROR:NAMESPACE_EXISTS:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
-        dd, cd, dd, nm
+        r#"Set ns("Globals")={dd}
+Set ns("Routines")={cd}
+Set ns("Database")={dd}
+Set tSC=##class(Config.Namespaces).Create({nm},.ns)
+If $$$ISERR(tSC) {{ Write "ERROR:NAMESPACE_EXISTS:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#
     );
     match iris.execute_via_generator(&code, "%SYS", &client).await {
         Ok(out) => {
@@ -612,13 +601,12 @@ pub async fn admin_delete_namespace_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let nm = name.replace('\'', "''");
+    let nm = os_str_expr(name);
     // Deletes namespace definition only — databases are NOT deleted (by design)
     let code = format!(
-        r#"If '##class(Config.Namespaces).Exists("{}") {{ Write "ERROR:NAMESPACE_NOT_FOUND:Namespace not found: {}" Quit }}
-Set tSC=##class(Config.Namespaces).Delete("{}")
-If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
-        nm, nm, nm
+        r#"If '##class(Config.Namespaces).Exists({nm}) {{ Write "ERROR:NAMESPACE_NOT_FOUND:Namespace not found: "_{nm} Quit }}
+Set tSC=##class(Config.Namespaces).Delete({nm})
+If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#
     );
     match iris.execute_via_generator(&code, "%SYS", &client).await {
         Ok(out) => {
@@ -652,18 +640,17 @@ pub async fn admin_create_webapp_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let p = path.replace('\'', "''");
-    let ns = namespace.replace('\'', "''");
-    let dc = dispatch_class.unwrap_or("").replace('\'', "''");
+    let p = os_str_expr(path);
+    let ns = os_str_expr(namespace);
+    let dc = os_str_expr(dispatch_class.unwrap_or(""));
     let en = if enabled { 1 } else { 0 };
     let code = format!(
-        r#"Set props("NameSpace")="{}"
-Set props("DispatchClass")="{}"
-Set props("Enabled")={}
+        r#"Set props("NameSpace")={ns}
+Set props("DispatchClass")={dc}
+Set props("Enabled")={en}
 Set props("AutheEnabled")=32
-Set tSC=##class(Security.Applications).Create("{}",.props)
-If $$$ISERR(tSC) {{ Write "ERROR:WEBAPP_EXISTS:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
-        ns, dc, en, p
+Set tSC=##class(Security.Applications).Create({p},.props)
+If $$$ISERR(tSC) {{ Write "ERROR:WEBAPP_EXISTS:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#
     );
     match iris.execute_via_generator(&code, "%SYS", &client).await {
         Ok(out) => {
@@ -694,13 +681,12 @@ pub async fn admin_delete_webapp_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let p = path.replace('\'', "''");
+    let p = os_str_expr(path);
     let code = format!(
-        r#"Set tSC=##class(Security.Applications).Get("{}",.props)
-If $$$ISERR(tSC) {{ Write "ERROR:WEBAPP_NOT_FOUND:Webapp not found: {}" Quit }}
-Set tSC2=##class(Security.Applications).Delete("{}")
-If $$$ISERR(tSC2) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC2) }} Else {{ Write "OK" }}"#,
-        p, p, p
+        r#"Set tSC=##class(Security.Applications).Get({p},.props)
+If $$$ISERR(tSC) {{ Write "ERROR:WEBAPP_NOT_FOUND:Webapp not found: "_{p} Quit }}
+Set tSC2=##class(Security.Applications).Delete({p})
+If $$$ISERR(tSC2) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC2) }} Else {{ Write "OK" }}"#
     );
     match iris.execute_via_generator(&code, "%SYS", &client).await {
         Ok(out) => {

--- a/crates/iris-agentic-dev-core/src/tools/dict.rs
+++ b/crates/iris-agentic-dev-core/src/tools/dict.rs
@@ -166,16 +166,16 @@ pub struct ExtractMessageMapParams {
 }
 
 fn build_message_map_code(cls: &str) -> String {
-    let cls_esc = cls.replace('\\', "\\\\").replace('"', "\\\"");
+    let cls_expr = crate::objectscript::os_str_expr(cls);
     let mut lines: Vec<String> = vec!["Set q=$CHAR(34)".into()];
     lines.push(format!(
-        r#"Set clsObj=##class(%Dictionary.CompiledClass).%OpenId("{}")"#,
-        cls_esc
+        r#"Set clsObj=##class(%Dictionary.CompiledClass).%OpenId({})"#,
+        cls_expr
     ));
     lines.push(r#"If '$IsObject(clsObj) { Write "NOT_FOUND",! Quit }"#.into());
     lines.push(format!(
-        r#"Set xd=##class(%Dictionary.CompiledXData).%OpenId("{}||MessageMap")"#,
-        cls_esc
+        r#"Set xd=##class(%Dictionary.CompiledXData).%OpenId({}_"||MessageMap")"#,
+        cls_expr
     ));
     lines.push(r#"If '$IsObject(xd) { Write "{"_q_"has_message_map"_q_":false,"_q_"routes"_q_":[]}", ! Quit }"#.into());
     lines.push("Do xd.Data.Rewind()".into());
@@ -587,7 +587,7 @@ mod tests {
     fn test_build_message_map_code_contains_key_fragments() {
         let code = build_message_map_code("HS.Flash.Router");
         assert!(
-            code.contains("HS.Flash.Router||MessageMap"),
+            code.contains(r#""HS.Flash.Router"_"||MessageMap""#),
             "must use || key"
         );
         assert!(

--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -1,4 +1,5 @@
 use crate::iris::connection::IrisConnection;
+use crate::objectscript::{os_str_expr, os_stream_write_stmts};
 use rmcp::{model::*, ErrorData as McpError};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -498,7 +499,7 @@ pub async fn interop_production_item_impl(
         Some(i) => i,
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
-    let item = params.item.replace('\'', "''");
+    let item = os_str_expr(&params.item);
     let ns = &params.namespace;
     let client = IrisConnection::http_client()
         .map_err(|_| McpError::invalid_request("IRIS_UNREACHABLE", None))?;
@@ -512,15 +513,14 @@ If $System.Status.IsError(tSC) {{ Write "ERROR:NO_PRODUCTION:"_$System.Status.Ge
 If n="" {{ Write "ERROR:NO_PRODUCTION:No production running" Quit }}
 Set tProd=##class(Ens.Config.Production).%OpenId(n,,.tSC2)
 If '$IsObject(tProd) {{ Write "ERROR:INTEROP_ERROR:Cannot open production" Quit }}
-Set tItem=tProd.FindItemByConfigName("{}",,.tSC3)
-If '$IsObject(tItem) {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: {}" Quit }}
-Set tItem.Enabled={}
+Set tItem=tProd.FindItemByConfigName({item},,.tSC3)
+If '$IsObject(tItem) {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: "_{item} Quit }}
+Set tItem.Enabled={enabled_val}
 Set tSC4=tProd.%Save()
 If $System.Status.IsError(tSC4) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC4) Quit }}
 Set tSC5=##class(Ens.Director).UpdateProduction(10,0)
 If $System.Status.IsError(tSC5) {{ Write "ERROR:UPDATE_FAILED:"_$System.Status.GetErrorText(tSC5) Quit }}
-Write "OK""#,
-                item, item, enabled_val
+Write "OK""#
             );
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
@@ -555,11 +555,10 @@ Write "OK""#,
 If $System.Status.IsError(tSC)||n="" {{ Write "ERROR:NO_PRODUCTION:No production running" Quit }}
 Set tProd=##class(Ens.Config.Production).%OpenId(n,,.tSC2)
 If '$IsObject(tProd) {{ Write "ERROR:INTEROP_ERROR:Cannot open production" Quit }}
-Set tItem=tProd.FindItemByConfigName("{}",,.tSC3)
-If '$IsObject(tItem) {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: {}" Quit }}
+Set tItem=tProd.FindItemByConfigName({item},,.tSC3)
+If '$IsObject(tItem) {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: "_{item} Quit }}
 Set tKey="" For {{ Set tSetting=tItem.Settings.GetNext(.tKey) Quit:tKey=""
-  Write tSetting.Name_"="_tSetting.Value_$CHAR(10) }}"#,
-                item, item
+  Write tSetting.Name_"="_tSetting.Value_$CHAR(10) }}"#
             );
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
@@ -610,14 +609,15 @@ Set tKey="" For {{ Set tSetting=tItem.Settings.GetNext(.tKey) Quit:tKey=""
             // Build ObjectScript to set each setting then UpdateProduction
             let mut setting_lines = String::new();
             for (k, v) in &params.settings {
-                let k_esc = k.replace('\'', "''");
-                let v_esc = v.replace('\'', "''");
+                let k_expr = os_str_expr(k);
+                let v_expr = os_str_expr(v);
                 setting_lines.push_str(&format!(
-                    r#"Set tS=tItem.FindSettingByName("{}","Host")
-If '$IsObject(tS) {{ Set tS=##class(Ens.Config.Setting).%New() Set tS.Name="{}" Set tS.Target="Host" Do tItem.Settings.Insert(tS) }}
-Set tS.Value="{}"
+                    r#"Set tS=tItem.FindSettingByName({k},"Host")
+If '$IsObject(tS) {{ Set tS=##class(Ens.Config.Setting).%New() Set tS.Name={k} Set tS.Target="Host" Do tItem.Settings.Insert(tS) }}
+Set tS.Value={v}
 "#,
-                    k_esc, k_esc, v_esc
+                    k = k_expr,
+                    v = v_expr
                 ));
             }
             let code = format!(
@@ -625,14 +625,13 @@ Set tS.Value="{}"
 If $System.Status.IsError(tSC)||n="" {{ Write "ERROR:NO_PRODUCTION:No production running" Quit }}
 Set tProd=##class(Ens.Config.Production).%OpenId(n,,.tSC2)
 If '$IsObject(tProd) {{ Write "ERROR:INTEROP_ERROR:Cannot open production" Quit }}
-Set tItem=tProd.FindItemByConfigName("{}",,.tSC3)
-If '$IsObject(tItem) {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: {}" Quit }}
-{}Set tSC4=tProd.%Save()
+Set tItem=tProd.FindItemByConfigName({item},,.tSC3)
+If '$IsObject(tItem) {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: "_{item} Quit }}
+{setting_lines}Set tSC4=tProd.%Save()
 If $System.Status.IsError(tSC4) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC4) Quit }}
 Set tSC5=##class(Ens.Director).UpdateProduction(10,0)
 If $System.Status.IsError(tSC5) {{ Write "ERROR:UPDATE_FAILED:"_$System.Status.GetErrorText(tSC5) Quit }}
-Write "OK""#,
-                item, item, setting_lines
+Write "OK""#
             );
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
@@ -750,21 +749,21 @@ pub async fn interop_credential_manage_impl(
     };
     let client = IrisConnection::http_client()
         .map_err(|_| McpError::invalid_request("IRIS_UNREACHABLE", None))?;
-    let id = params.id.replace('\'', "''");
+    let id = os_str_expr(&params.id);
     let ns = &params.namespace;
 
     match params.action.as_str() {
         "create" => {
             let username = match &params.username {
-                Some(u) => u.replace('\'', "''"),
+                Some(u) => os_str_expr(u),
                 None => return err_json("INVALID_PARAMS", "create requires username"),
             };
             let password = match &params.password {
-                Some(p) => p.replace('\'', "''"),
+                Some(p) => os_str_expr(p),
                 None => return err_json("INVALID_PARAMS", "create requires password"),
             };
             let code = format!(
-                r#"Set tSC=##class(Ens.Config.Credentials).SetCredential("{}","{}","{}",0)
+                r#"Set tSC=##class(Ens.Config.Credentials).SetCredential({},{},{},0)
 If $System.Status.IsError(tSC) {{ Write "ERROR:CREDENTIAL_EXISTS:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
                 id, username, password
             );
@@ -794,21 +793,21 @@ If $System.Status.IsError(tSC) {{ Write "ERROR:CREDENTIAL_EXISTS:"_$System.Statu
         "update" => {
             // Read current values then overwrite with provided ones
             let username_expr = match &params.username {
-                Some(u) => format!("\"{}\"", u.replace('\'', "''")),
+                Some(u) => os_str_expr(u),
                 None => format!(
-                    "##class(Ens.Config.Credentials).GetValue(\"{}\",\"Username\")",
+                    "##class(Ens.Config.Credentials).GetValue({},\"Username\")",
                     id
                 ),
             };
             let password_expr = match &params.password {
-                Some(p) => format!("\"{}\"", p.replace('\'', "''")),
+                Some(p) => os_str_expr(p),
                 None => format!(
-                    "##class(Ens.Config.Credentials).GetValue(\"{}\",\"Password\")",
+                    "##class(Ens.Config.Credentials).GetValue({},\"Password\")",
                     id
                 ),
             };
             let code = format!(
-                r#"Set tSC=##class(Ens.Config.Credentials).SetCredential("{}",{},{},1)
+                r#"Set tSC=##class(Ens.Config.Credentials).SetCredential({},{},{},1)
 If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
                 id, username_expr, password_expr
             );
@@ -835,10 +834,9 @@ If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.Ge
         }
         "delete" => {
             let code = format!(
-                r#"If '##class(Ens.Config.Credentials).%ExistsId("{}") {{ Write "ERROR:CREDENTIAL_NOT_FOUND:Credential not found: {}" Quit }}
-Set tSC=##class(Ens.Config.Credentials).%DeleteId("{}")
-If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
-                id, id, id
+                r#"If '##class(Ens.Config.Credentials).%ExistsId({id}) {{ Write "ERROR:CREDENTIAL_NOT_FOUND:Credential not found: "_{id} Quit }}
+Set tSC=##class(Ens.Config.Credentials).%DeleteId({id})
+If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#
             );
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
@@ -934,19 +932,18 @@ pub async fn interop_lookup_manage_impl(
         }
         "get" => {
             let table = match &params.table {
-                Some(t) => t.replace('\'', "''"),
+                Some(t) => os_str_expr(t),
                 None => return err_json("INVALID_PARAMS", "get requires table"),
             };
             let key = match &params.key {
-                Some(k) => k.replace('\'', "''"),
+                Some(k) => os_str_expr(k),
                 None => return err_json("INVALID_PARAMS", "get requires key"),
             };
             let code = format!(
-                r#"If '$DATA(^Ens.LookupTable("{}")) {{ Write "ERROR:TABLE_NOT_FOUND:Table not found: {}" Quit }}
-Set tVal=$GET(^Ens.LookupTable("{}","{}"))
-If tVal="" {{ Write "ERROR:KEY_NOT_FOUND:Key not found: {}" Quit }}
-Write tVal"#,
-                table, table, table, key, key
+                r#"If '$DATA(^Ens.LookupTable({table})) {{ Write "ERROR:TABLE_NOT_FOUND:Table not found: "_{table} Quit }}
+Set tVal=$GET(^Ens.LookupTable({table},{key}))
+If tVal="" {{ Write "ERROR:KEY_NOT_FOUND:Key not found: "_{key} Quit }}
+Write tVal"#
             );
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
@@ -973,21 +970,20 @@ Write tVal"#,
         }
         "set" => {
             let table = match &params.table {
-                Some(t) => t.replace('\'', "''"),
+                Some(t) => os_str_expr(t),
                 None => return err_json("INVALID_PARAMS", "set requires table"),
             };
             let key = match &params.key {
-                Some(k) => k.replace('\'', "''"),
+                Some(k) => os_str_expr(k),
                 None => return err_json("INVALID_PARAMS", "set requires key"),
             };
             let value = match &params.value {
-                Some(v) => v.replace('\'', "''"),
+                Some(v) => os_str_expr(v),
                 None => return err_json("INVALID_PARAMS", "set requires value"),
             };
             let code = format!(
-                r#"Set tSC=##class(Ens.Util.LookupTable).%UpdateValue("{}","{}","{}",1)
-If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
-                table, key, value
+                r#"Set tSC=##class(Ens.Util.LookupTable).%UpdateValue({table},{key},{value},1)
+If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#
             );
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
@@ -1012,18 +1008,17 @@ If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.Ge
         }
         "delete" => {
             let table = match &params.table {
-                Some(t) => t.replace('\'', "''"),
+                Some(t) => os_str_expr(t),
                 None => return err_json("INVALID_PARAMS", "delete requires table"),
             };
             let key = match &params.key {
-                Some(k) => k.replace('\'', "''"),
+                Some(k) => os_str_expr(k),
                 None => return err_json("INVALID_PARAMS", "delete requires key"),
             };
             let code = format!(
-                r#"If '$DATA(^Ens.LookupTable("{}")) {{ Write "ERROR:TABLE_NOT_FOUND:Table not found: {}" Quit }}
-Set tSC=##class(Ens.Util.LookupTable).%RemoveValue("{}","{}")
-If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
-                table, table, table, key
+                r#"If '$DATA(^Ens.LookupTable({table})) {{ Write "ERROR:TABLE_NOT_FOUND:Table not found: "_{table} Quit }}
+Set tSC=##class(Ens.Util.LookupTable).%RemoveValue({table},{key})
+If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#
             );
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
@@ -1050,13 +1045,12 @@ If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.Ge
         }
         "list_keys" => {
             let table = match &params.table {
-                Some(t) => t.replace('\'', "''"),
+                Some(t) => os_str_expr(t),
                 None => return err_json("INVALID_PARAMS", "list_keys requires table"),
             };
             let code = format!(
-                r#"If '$DATA(^Ens.LookupTable("{}")) {{ Write "ERROR:TABLE_NOT_FOUND:Table not found: {}" Quit }}
-Set tKey="" For {{ Set tKey=$ORDER(^Ens.LookupTable("{}",tKey)) Quit:tKey=""  Write tKey_$CHAR(10) }}"#,
-                table, table, table
+                r#"If '$DATA(^Ens.LookupTable({table})) {{ Write "ERROR:TABLE_NOT_FOUND:Table not found: "_{table} Quit }}
+Set tKey="" For {{ Set tKey=$ORDER(^Ens.LookupTable({table},tKey)) Quit:tKey=""  Write tKey_$CHAR(10) }}"#
             );
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
@@ -1090,6 +1084,29 @@ Set tKey="" For {{ Set tKey=$ORDER(^Ens.LookupTable("{}",tKey)) Quit:tKey=""  Wr
     }
 }
 
+/// Generated code that writes the XML to a server-side temp file and runs
+/// `Ens.Util.LookupTable.%Import`. The XML is user-supplied free text (quotes,
+/// newlines, unicode), so it is embedded via `os_stream_write_stmts` — C-style
+/// `\"` escaping made every import die with `<SYNTAX>` (XML always carries
+/// attribute quotes).
+fn build_lookup_import_code(table: &str, xml: &str) -> String {
+    let table_expr = os_str_expr(table);
+    let write_block = os_stream_write_stmts("tStream", xml, 400).join("\n");
+    format!(
+        r#"Set tFile=##class(%Library.File).TempFilename("xml")
+Set tStream=##class(%Stream.FileCharacter).%New()
+Set tStream.Filename=tFile
+Set tStream.TranslateTable="UTF8"
+{write_block}
+Set tSC=tStream.%Save()
+If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:Cannot write temp file" Quit }}
+Set tSC2=##class(Ens.Util.LookupTable).%Import(tFile,{table_expr},"")
+Do ##class(%File).Delete(tFile)
+If $System.Status.IsError(tSC2) {{ Write "ERROR:INVALID_XML:"_$System.Status.GetErrorText(tSC2) Quit }}
+Write "OK""#
+    )
+}
+
 pub async fn interop_lookup_transfer_impl(
     iris: Option<&IrisConnection>,
     params: LookupTransferParams,
@@ -1101,19 +1118,18 @@ pub async fn interop_lookup_transfer_impl(
     let client = IrisConnection::http_client()
         .map_err(|_| McpError::invalid_request("IRIS_UNREACHABLE", None))?;
     let ns = &params.namespace;
-    let table = params.table.replace('\'', "''");
+    let table = os_str_expr(&params.table);
 
     match params.action.as_str() {
         "export" => {
             let code = format!(
-                r#"If '$DATA(^Ens.LookupTable("{}")) {{ Write "ERROR:TABLE_NOT_FOUND:Table not found: {}" Quit }}
+                r#"If '$DATA(^Ens.LookupTable({table})) {{ Write "ERROR:TABLE_NOT_FOUND:Table not found: "_{table} Quit }}
 Set tStream=##class(%Stream.TmpBinary).%New()
-Set tSC=##class(Ens.Util.LookupTable).%Export(tStream,"{}")
+Set tSC=##class(Ens.Util.LookupTable).%Export(tStream,{table})
 If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) Quit }}
 Do tStream.Rewind()
 Set tOut="" While 'tStream.AtEnd {{ Set tOut=tOut_tStream.Read(32000) }}
-Write tOut"#,
-                table, table, table
+Write tOut"#
             );
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
@@ -1146,20 +1162,7 @@ Write tOut"#,
                 None => return err_json("INVALID_PARAMS", "import requires xml"),
             };
             // Write XML to temp file, import, delete
-            let xml_escaped = xml.replace('\\', "\\\\").replace('"', "\\\"");
-            let code = format!(
-                r#"Set tFile=##class(%Library.File).TempFilename("xml")
-Set tStream=##class(%Stream.FileCharacter).%New()
-Set tStream.Filename=tFile
-Do tStream.Write("{}")
-Set tSC=tStream.%Save()
-If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:Cannot write temp file" Quit }}
-Set tSC2=##class(Ens.Util.LookupTable).%Import(tFile,"{}","")
-Do ##class(%File).Delete(tFile)
-If $System.Status.IsError(tSC2) {{ Write "ERROR:INVALID_XML:"_$System.Status.GetErrorText(tSC2) Quit }}
-Write "OK""#,
-                xml_escaped, table
-            );
+            let code = build_lookup_import_code(&params.table, &xml);
             match iris.execute_via_generator(&code, ns, &client).await {
                 Ok(out) => {
                     let out = out.trim();
@@ -1276,7 +1279,7 @@ If $System.Status.IsError(tSC) { Write "ERROR:INTEROP_ERROR:"_$System.Status.Get
 
     // enabled=true: resolve production name
     let prod_name = if let Some(p) = &params.production {
-        p.replace('\'', "''")
+        p.clone()
     } else {
         // Get currently running production
         let status_code = r#"Set sc=##class(Ens.Director).GetProductionStatus(.n,.s) If $System.Status.IsError(sc)||n="" { Write "ERROR:NO_PRODUCTION:No production running" } Else { Write n }"#;
@@ -1302,9 +1305,9 @@ If $System.Status.IsError(tSC) { Write "ERROR:INTEROP_ERROR:"_$System.Status.Get
     };
 
     let code = format!(
-        r#"Set tSC=##class(Ens.Director).SetAutoStart("{}")
+        r#"Set tSC=##class(Ens.Director).SetAutoStart({})
 If $System.Status.IsError(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC) }} Else {{ Write "OK" }}"#,
-        prod_name
+        os_str_expr(&prod_name)
     );
     match iris.execute_via_generator(&code, ns, &client).await {
         Ok(out) if out.trim() == "OK" => ok_json(
@@ -2881,43 +2884,75 @@ mod tests {
         assert!(!is_network_error("DNS Error"));
     }
 
+    // Every line of generated ObjectScript must hold only complete string
+    // literals: an odd number of `"` on a line means a literal was torn open
+    // by an embedded quote or newline — exactly the escaping bug's <SYNTAX>.
+    fn assert_valid_objectscript_lines(code: &str) {
+        for line in code.lines() {
+            assert_eq!(
+                line.matches('"').count() % 2,
+                0,
+                "unbalanced quotes in generated line: {line}"
+            );
+        }
+        assert!(
+            !code.contains("\\\""),
+            "generated code must never use C-style quote escaping"
+        );
+    }
+
     #[test]
     fn production_item_escape_in_objectscript_code() {
-        let item = "Service'Name";
-        let escaped = item.replace('\'', "''");
-        assert_eq!(escaped, "Service''Name");
-        // Verify escaping would work in a format string
-        let code = format!(r#"Set tItem=tProd.FindItemByConfigName("{}")"#, escaped);
-        assert!(code.contains("Service''Name"));
+        // apostrophes pass through untouched — ObjectScript literals only escape `"`
+        let item = os_str_expr("Service'Name");
+        assert_eq!(item, "\"Service'Name\"");
+        let code = format!(r#"Set tItem=tProd.FindItemByConfigName({item})"#);
+        assert_valid_objectscript_lines(&code);
+        assert!(code.contains("Service'Name"));
     }
 
     #[test]
     fn credential_id_escaping() {
-        let id = "Cred'With'Quotes";
-        let escaped = id.replace('\'', "''");
-        assert_eq!(escaped, "Cred''With''Quotes");
+        assert_eq!(os_str_expr("Cred'With'Quotes"), "\"Cred'With'Quotes\"");
     }
 
     #[test]
     fn credential_username_escaping() {
-        let username = "user'name@example.com";
-        let escaped = username.replace('\'', "''");
-        assert_eq!(escaped, "user''name@example.com");
+        assert_eq!(
+            os_str_expr("user'name@example.com"),
+            "\"user'name@example.com\""
+        );
     }
 
     #[test]
     fn credential_password_escaping() {
-        let password = "pass'word!@#$%";
-        let escaped = password.replace('\'', "''");
-        assert_eq!(escaped, "pass''word!@#$%");
+        // SQL-style '' doubling here would silently corrupt the stored password
+        assert_eq!(os_str_expr("pass'word!@#$%"), "\"pass'word!@#$%\"");
+        assert_eq!(os_str_expr(r#"pa"ss"#), r#""pa""ss""#);
     }
 
     #[test]
-    fn xml_escaping_backslash_and_quote() {
-        let xml = r#"<value path="C:\Users\test">"#;
-        let escaped = xml.replace('\\', "\\\\").replace('"', "\\\"");
-        assert!(escaped.contains("\\\\"));
-        assert!(escaped.contains("\\\""));
+    fn lookup_import_code_survives_real_xml() {
+        // Quote-heavy multi-line XML — the shape %Export produces
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<lookupTable>\n<entry table=\"T1\" key=\"M\">1</entry>\n</lookupTable>";
+        let code = build_lookup_import_code("T1", xml);
+        assert_valid_objectscript_lines(&code);
+        assert!(code.contains(r#"table=""T1"""#), "quotes doubled: {code}");
+        assert!(code.contains("$CHAR(10)"), "newlines spliced via $CHAR");
+        assert!(code.contains(r#"%Import(tFile,"T1","")"#));
+    }
+
+    #[test]
+    fn lookup_import_code_chunks_large_single_line_xml() {
+        let xml = format!("<lookupTable>{}</lookupTable>", "x".repeat(5000));
+        let code = build_lookup_import_code("T", &xml);
+        assert_valid_objectscript_lines(&code);
+        let writes = code.matches("Do tStream.Write(").count();
+        assert!(
+            writes > 1,
+            "long payload must span several Write statements"
+        );
+        assert!(code.lines().all(|l| l.len() < 2000), "no oversized lines");
     }
 
     #[test]

--- a/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
@@ -301,8 +301,9 @@ fn test_lookup_crud() {
     let ns = std::env::var("IRIS_NAMESPACE").unwrap_or_else(|_| "USER".to_string());
     let table = "IrisDevTestTable";
 
-    // set 3 keys
-    for (key, val) in &[("Key1", "Val1"), ("Key2", "Val2"), ("Key3", "Val3")] {
+    // set 3 keys — Key3's value carries a quote, an apostrophe and an accent:
+    // the old SQL-style escaping corrupted ' to '' and died with <SYNTAX> on "
+    for (key, val) in &[("Key1", "Val1"), ("Key2", "Val2"), ("Key3", "Va\"l'ñ3")] {
         let start = Instant::now();
         let responses = mcp_exchange(&[
             serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
@@ -311,7 +312,7 @@ fn test_lookup_crud() {
         ]);
         assert!(start.elapsed().as_secs() < 3, "SC-003: set exceeded 3s");
         let r = parse_tool_text(&find_response(&responses, 2).expect("no response"));
-        assert!(r["success"] == true || r.get("error_code").is_some());
+        assert_eq!(r["success"], true, "set {key} failed: {r}");
     }
 
     // list_tables — assert table present
@@ -321,14 +322,13 @@ fn test_lookup_crud() {
         serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"iris_lookup_manage","arguments":{"action":"list_tables","namespace":ns}}}),
     ]);
     let lt = parse_tool_text(&find_response(&resp_lt, 2).expect("no response"));
-    if lt["success"] == true {
-        let empty = vec![];
-        let tables = lt["tables"].as_array().unwrap_or(&empty);
-        assert!(
-            tables.iter().any(|t| t.as_str() == Some(table)),
-            "table must appear in list_tables"
-        );
-    }
+    assert_eq!(lt["success"], true, "list_tables failed: {lt}");
+    let empty = vec![];
+    let tables = lt["tables"].as_array().unwrap_or(&empty);
+    assert!(
+        tables.iter().any(|t| t.as_str() == Some(table)),
+        "table must appear in list_tables"
+    );
 
     // export
     let resp_ex = mcp_exchange(&[
@@ -337,7 +337,9 @@ fn test_lookup_crud() {
         serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"iris_lookup_transfer","arguments":{"action":"export","table":table,"namespace":ns}}}),
     ]);
     let ex = parse_tool_text(&find_response(&resp_ex, 2).expect("no response"));
+    assert_eq!(ex["success"], true, "export failed: {ex}");
     let xml = ex["xml"].as_str().unwrap_or("");
+    assert!(!xml.is_empty(), "export must return the XML");
 
     // delete keys
     for key in &["Key1", "Key2", "Key3"] {
@@ -349,33 +351,39 @@ fn test_lookup_crud() {
         let _ = find_response(&responses, 2);
     }
 
-    // import and verify round-trip
-    if !xml.is_empty() {
-        let resp_im = mcp_exchange(&[
-            serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
-            serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
-            serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"iris_lookup_transfer","arguments":{"action":"import","table":table,"xml":xml,"namespace":ns}}}),
-        ]);
-        let im = parse_tool_text(&find_response(&resp_im, 2).expect("no response"));
-        assert!(
-            im["success"] == true || im.get("error_code").is_some(),
-            "import must return success or error_code"
-        );
+    // import and verify round-trip — issue #6: this failed 7/7 with <SYNTAX>
+    let resp_im = mcp_exchange(&[
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
+        serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
+        serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"iris_lookup_transfer","arguments":{"action":"import","table":table,"xml":xml,"namespace":ns}}}),
+    ]);
+    let im = parse_tool_text(&find_response(&resp_im, 2).expect("no response"));
+    assert_eq!(im["success"], true, "import failed: {im}");
 
-        // verify Key1 restored
+    // verify values restored, including the quote/apostrophe/accent one
+    for (key, want) in &[("Key1", "Val1"), ("Key3", "Va\"l'ñ3")] {
         let resp_get = mcp_exchange(&[
             serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
             serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
-            serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"iris_lookup_manage","arguments":{"action":"get","table":table,"key":"Key1","namespace":ns}}}),
+            serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"iris_lookup_manage","arguments":{"action":"get","table":table,"key":key,"namespace":ns}}}),
         ]);
         let g = parse_tool_text(&find_response(&resp_get, 2).expect("no response"));
-        if g["success"] == true {
-            assert_eq!(
-                g["value"].as_str(),
-                Some("Val1"),
-                "SC-005: round-trip value must match"
-            );
-        }
+        assert_eq!(g["success"], true, "get {key} after import failed: {g}");
+        assert_eq!(
+            g["value"].as_str(),
+            Some(*want),
+            "SC-005: round-trip value must match for {key}"
+        );
+    }
+
+    // leave the namespace clean
+    for key in &["Key1", "Key2", "Key3"] {
+        let responses = mcp_exchange(&[
+            serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
+            serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
+            serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"iris_lookup_manage","arguments":{"action":"delete","table":table,"key":key,"namespace":ns}}}),
+        ]);
+        let _ = find_response(&responses, 2);
     }
 }
 


### PR DESCRIPTION
Fixes #92

## What

Every tool that generates ObjectScript embedded user-supplied strings into ObjectScript `"..."` literals with the wrong escaping for the context: SQL-style `''` doubling, or C-style `\\` / `\"`. ObjectScript escapes a quote inside a literal by doubling it (`""`); backslash is an ordinary character. As a result:

- `iris_lookup_transfer action=import` failed 100% with `<SYNTAX>` — `%Export` XML always carries attribute quotes, and `\"` tears the literal open
- values containing `'` were silently written doubled (`success:true`): credential passwords (`Ens.Config.Credentials.SetCredential`), `Security.Users` passwords, lookup values, production item settings
- values containing `"` or newlines crashed the generated routine

## How

New module `crates/iris-agentic-dev-core/src/objectscript.rs`:

- `os_str_expr(s)` — renders any string as a single-line ObjectScript expression: printable runs become quoted literals with `"` doubled, control characters are spliced via `$CHAR(n,...)` (a literal cannot span source lines, and the exec-class builder splits on `\n`)
- `os_stream_write_stmts(var, payload, chunk)` — chunked `Do var.Write(...)` statements for long payloads (the import XML), so no generated line approaches the routine line-length limit

Converted every ObjectScript-context embed site:

- `tools/interop.rs` — production item enable/disable/get_settings/set_settings, credential create/update/delete, lookup manage get/set/delete/list_keys, lookup transfer export/import (import now goes through `build_lookup_import_code`, unit-tested), autostart set
- `tools/admin.rs` — user get-roles/create/modify/delete, security check, namespace create/delete, webapp get/create/delete
- `tools/dict.rs` — `build_message_map_code` class-name embed

SQL-context escapes (`iris.query` paths, `coverage.rs`, `info.rs`) are untouched — `''` doubling is correct there.

The unit tests that asserted the wrong escaping (`production_item_escape_in_objectscript_code`, `credential_*_escaping`, `xml_escaping_backslash_and_quote`) now assert the correct behavior, plus new tests that feed real quote-heavy multi-line XML through the import code builder and check every generated line holds only balanced literals.

## Testing

- `cargo build` clean, `cargo clippy --all-targets` clean, `cargo fmt` applied
- `cargo test -p iris-agentic-dev-core --lib`: 1002 passed, 0 failed
- e2e test file compiles; the live lookup round-trip test now asserts real success (the old asserts accepted `error_code` as a pass, which is how the 7/7 import failures stayed green) and exercises a quote/apostrophe/accent value against a live IRIS

This is a port of intersystems-ib/iris-interop-dev#7 (where the bug was found and fixed against a 0.6.x base), re-applied onto current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
