### PR TITLE
fix(mcp): set isError on genuine tool failures (fixes #95)

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/admin.rs
+++ b/crates/iris-agentic-dev-core/src/tools/admin.rs
@@ -9,7 +9,9 @@ fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(v.to_string())]))
 }
 fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {
-    ok_json(serde_json::json!({"success": false, "error_code": code, "error": msg}))
+    crate::tools::err_result(
+        serde_json::json!({"success": false, "error_code": code, "error": msg}),
+    )
 }
 fn iris_unreachable() -> McpError {
     McpError::invalid_request("IRIS_UNREACHABLE", None)
@@ -845,6 +847,7 @@ mod tests {
     #[test]
     fn test_err_json_code_and_message() {
         let result = err_json("TEST_ERROR", "This is a test error message").unwrap();
+        assert_eq!(result.is_error, Some(true));
         let text = result.content[0].raw.as_text().unwrap().text.clone();
         let v: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(v["error_code"], "TEST_ERROR");

--- a/crates/iris-agentic-dev-core/src/tools/admin_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/admin_tools.rs
@@ -34,7 +34,7 @@ fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
 }
 
 fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {
-    ok_json(serde_json::json!({
+    crate::tools::err_result(serde_json::json!({
         "success": false,
         "error_code": code,
         "error": msg,
@@ -204,7 +204,7 @@ pub async fn global_kill_impl(
             "global": name,
         }))
     } else {
-        ok_json(serde_json::json!({
+        crate::tools::err_result(serde_json::json!({
             "success": false,
             "error_code": "IRIS_EXECUTE_ERROR",
             "error": format!("Unexpected output: {out}"),

--- a/crates/iris-agentic-dev-core/src/tools/comparison_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/comparison_tools.rs
@@ -135,12 +135,12 @@ pub async fn compare_document_impl(
     .await;
 
     match (source_a, source_b) {
-        (Err(e), _) => ok_json(serde_json::json!({
+        (Err(e), _) => crate::tools::err_result(serde_json::json!({
             "success": false,
             "error_code": ERR_COMPARE_FETCH_FAILED,
             "error": format!("Failed to fetch from server_a: {e}"),
         })),
-        (_, Err(e)) => ok_json(serde_json::json!({
+        (_, Err(e)) => crate::tools::err_result(serde_json::json!({
             "success": false,
             "error_code": ERR_COMPARE_FETCH_FAILED,
             "error": format!("Failed to fetch from server_b: {e}"),
@@ -182,14 +182,14 @@ pub async fn compare_namespace_impl(
 
     let (list_a, list_b) = match (list_a, list_b) {
         (Err(e), _) => {
-            return ok_json(serde_json::json!({
+            return crate::tools::err_result(serde_json::json!({
                 "success": false,
                 "error_code": ERR_COMPARE_FETCH_FAILED,
                 "error": format!("Failed to list from server_a: {e}"),
             }))
         }
         (_, Err(e)) => {
-            return ok_json(serde_json::json!({
+            return crate::tools::err_result(serde_json::json!({
                 "success": false,
                 "error_code": ERR_COMPARE_FETCH_FAILED,
                 "error": format!("Failed to list from server_b: {e}"),

--- a/crates/iris-agentic-dev-core/src/tools/dict.rs
+++ b/crates/iris-agentic-dev-core/src/tools/dict.rs
@@ -44,7 +44,9 @@ fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::Er
 }
 
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    ok_json(serde_json::json!({"success": false, "error_code": code, "error": msg}))
+    crate::tools::err_result(
+        serde_json::json!({"success": false, "error_code": code, "error": msg}),
+    )
 }
 
 fn default_namespace() -> String {

--- a/crates/iris-agentic-dev-core/src/tools/doc.rs
+++ b/crates/iris-agentic-dev-core/src/tools/doc.rs
@@ -160,7 +160,9 @@ fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::Er
     ]))
 }
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    ok_json(serde_json::json!({"success": false, "error_code": code, "error": msg}))
+    crate::tools::err_result(
+        serde_json::json!({"success": false, "error_code": code, "error": msg}),
+    )
 }
 
 /// Return the trimmed document name, or a MISSING_PARAMS result if absent/blank.
@@ -171,7 +173,7 @@ fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::
 fn require_name(p: &IrisDocParams, mode: &str) -> Result<String, rmcp::model::CallToolResult> {
     match p.name.as_deref().map(str::trim) {
         Some(n) if !n.is_empty() => Ok(n.to_string()),
-        _ => Err(rmcp::model::CallToolResult::success(vec![
+        _ => Err(rmcp::model::CallToolResult::error(vec![
             rmcp::model::Content::text(
                 serde_json::json!({
                     "success": false,
@@ -226,7 +228,7 @@ pub async fn handle_iris_doc(
         if let Some(pending) = elicitation_store.lookup(eid) {
             elicitation_store.clear(eid);
             if answer.to_lowercase() != "yes" {
-                return ok_json(serde_json::json!({
+                return crate::tools::err_result(serde_json::json!({
                     "success": false,
                     "error_code": "WRITE_ABORTED",
                     "error": "User declined checkout",
@@ -990,7 +992,7 @@ fn stale_content_err(
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     let (off, expected, actual) = diff;
     let line_no = block_start + off as i64;
-    ok_json(serde_json::json!({
+    crate::tools::err_result(serde_json::json!({
         "success": false,
         "error_code": "STALE_CONTENT",
         "error": format!(
@@ -1531,7 +1533,7 @@ async fn handle_list(
     };
 
     if let Err(e) = validate_list_pattern(pattern) {
-        return ok_json(e);
+        return crate::tools::err_result(e);
     }
 
     let category = p.category.as_deref().unwrap_or("ALL").to_uppercase();
@@ -2407,6 +2409,7 @@ mod tests {
     #[test]
     fn test_err_json_creates_error_response() {
         let result = err_json("TEST_ERROR", "Test message").unwrap();
+        assert_eq!(result.is_error, Some(true));
         let text = result.content[0].raw.as_text().unwrap().text.clone();
         let v: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(v["success"], false);

--- a/crates/iris-agentic-dev-core/src/tools/info.rs
+++ b/crates/iris-agentic-dev-core/src/tools/info.rs
@@ -15,7 +15,9 @@ fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::Er
     ]))
 }
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    ok_json(serde_json::json!({"success": false, "error_code": code, "error": msg}))
+    crate::tools::err_result(
+        serde_json::json!({"success": false, "error_code": code, "error": msg}),
+    )
 }
 fn default_namespace() -> String {
     "USER".to_string()
@@ -228,10 +230,12 @@ pub async fn handle_iris_debug(
                 Ok(output) => ok_json(
                     serde_json::json!({"success": true, "error_string": err, "source_location": output.trim()}),
                 ),
-                Err(e) if e.to_string() == "DOCKER_REQUIRED" => ok_json(serde_json::json!({
-                    "success": false, "error_code": "DOCKER_REQUIRED",
-                    "error": "iris_debug map_int requires docker exec. Set IRIS_CONTAINER=<container_name>.",
-                })),
+                Err(e) if e.to_string() == "DOCKER_REQUIRED" => {
+                    crate::tools::err_result(serde_json::json!({
+                        "success": false, "error_code": "DOCKER_REQUIRED",
+                        "error": "iris_debug map_int requires docker exec. Set IRIS_CONTAINER=<container_name>.",
+                    }))
+                }
                 Err(e) => err_json("EXECUTION_FAILED", &e.to_string()),
             }
         }
@@ -251,10 +255,12 @@ pub async fn handle_iris_debug(
                 Ok(output) => {
                     ok_json(serde_json::json!({"success": true, "capture": output.trim()}))
                 }
-                Err(e) if e.to_string() == "DOCKER_REQUIRED" => ok_json(serde_json::json!({
-                    "success": false, "error_code": "DOCKER_REQUIRED",
-                    "error": "iris_debug capture requires docker exec. Set IRIS_CONTAINER=<container_name>.",
-                })),
+                Err(e) if e.to_string() == "DOCKER_REQUIRED" => {
+                    crate::tools::err_result(serde_json::json!({
+                        "success": false, "error_code": "DOCKER_REQUIRED",
+                        "error": "iris_debug capture requires docker exec. Set IRIS_CONTAINER=<container_name>.",
+                    }))
+                }
                 Err(e) => err_json("EXECUTION_FAILED", &e.to_string()),
             }
         }
@@ -268,10 +274,12 @@ pub async fn handle_iris_debug(
                 Ok(output) => ok_json(
                     serde_json::json!({"success": true, "class": cls, "mapping": output.trim()}),
                 ),
-                Err(e) if e.to_string() == "DOCKER_REQUIRED" => ok_json(serde_json::json!({
-                    "success": false, "error_code": "DOCKER_REQUIRED",
-                    "error": "iris_debug source_map requires docker exec. Set IRIS_CONTAINER=<container_name>.",
-                })),
+                Err(e) if e.to_string() == "DOCKER_REQUIRED" => {
+                    crate::tools::err_result(serde_json::json!({
+                        "success": false, "error_code": "DOCKER_REQUIRED",
+                        "error": "iris_debug source_map requires docker exec. Set IRIS_CONTAINER=<container_name>.",
+                    }))
+                }
                 Err(e) => err_json("EXECUTION_FAILED", &e.to_string()),
             }
         }
@@ -478,7 +486,7 @@ if rs.%Next() {{
         output.lines().filter_map(|l| l.split_once(':')).collect();
 
     if output.trim() == "NOT_FOUND" {
-        return crate::tools::ok_json(serde_json::json!({
+        return crate::tools::err_result(serde_json::json!({
             "success": false,
             "error": format!("Table '{}' not found in namespace '{}'", p.table, p.namespace),
             "table": p.table,

--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -7,7 +7,9 @@ fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(v.to_string())]))
 }
 fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {
-    ok_json(serde_json::json!({"success": false, "error_code": code, "error": msg}))
+    crate::tools::err_result(
+        serde_json::json!({"success": false, "error_code": code, "error": msg}),
+    )
 }
 fn iris_unreachable() -> McpError {
     McpError::invalid_request("IRIS_UNREACHABLE", None)
@@ -2829,6 +2831,7 @@ mod tests {
     #[test]
     fn err_json_response_structure() {
         let result = err_json("TEST_ERROR", "Something went wrong").unwrap();
+        assert_eq!(result.is_error, Some(true));
         let text = result.content[0].raw.as_text().unwrap().text.clone();
         let v: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(v["success"], false);

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -1157,8 +1157,28 @@ pub fn telemetry_config_dir() -> std::path::PathBuf {
 fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::text(v.to_string())]))
 }
+/// Wrap a genuine tool-failure envelope: same JSON body as before, but with the
+/// MCP protocol-level `isError` flag set (issue #95). Dialog/soft responses
+/// (elicitation prompts, empty-result notes) must NOT go through this — they are
+/// normal outcomes and stay `CallToolResult::success`.
+pub(crate) fn err_result(v: serde_json::Value) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::error(vec![Content::text(v.to_string())]))
+}
+/// Wrap a handler-produced JSON value whose error-ness is only known at runtime:
+/// a body carrying a top-level `error_code` without `success: true` is a genuine
+/// failure and gets the `isError` flag; everything else (successes, failing test
+/// runs without an error_code, elicitation dialogs) stays a success result.
+fn json_result(v: serde_json::Value) -> Result<CallToolResult, McpError> {
+    let genuine_error = v.get("error_code").is_some()
+        && v.get("success").and_then(serde_json::Value::as_bool) != Some(true);
+    if genuine_error {
+        err_result(v)
+    } else {
+        ok_json(v)
+    }
+}
 fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {
-    ok_json(serde_json::json!({"success": false, "error_code": code, "error": msg}))
+    err_result(serde_json::json!({"success": false, "error_code": code, "error": msg}))
 }
 
 /// Parse `"http://host:port"` into `(host, port)`.
@@ -1642,7 +1662,7 @@ async fn iris_query_write(
             );
         }
         Err(keyword) => {
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "success": false,
                 "error_code": "DDL_NOT_ALLOWED",
                 "error": format!("DDL keyword '{keyword}' is not allowed in mode=\"write\"."),
@@ -1688,7 +1708,7 @@ If rs.%Next() {{ Write "OK:"_rs.%GetData(1) }} Else {{ Write "OK:0" }}"#,
                             .and_then(|s| s.parse().ok())
                             .unwrap_or(0);
                         if actual_count > max_rows_affected as i64 {
-                            return ok_json(serde_json::json!({
+                            return err_result(serde_json::json!({
                                 "success": false,
                                 "error_code": "ROWS_LIMIT_EXCEEDED",
                                 "error": format!(
@@ -1799,7 +1819,7 @@ fn err_json_with_url(
     msg: &str,
     attempted_url: &str,
 ) -> Result<CallToolResult, McpError> {
-    ok_json(serde_json::json!({
+    err_result(serde_json::json!({
         "success": false,
         "error_code": code,
         "error": msg,
@@ -2819,7 +2839,7 @@ impl IrisTools {
                 None,
                 params_json,
             );
-            return ok_json(gate);
+            return err_result(gate);
         }
         if let Some(gate) = crate::iris::server_manager::policy_gate(
             "iris_compile",
@@ -2840,7 +2860,7 @@ impl IrisTools {
                 allowed,
                 params_json,
             );
-            return ok_json(gate);
+            return err_result(gate);
         }
         self.write_audit_entry(
             "iris_compile",
@@ -2859,7 +2879,7 @@ impl IrisTools {
             &instance_name,
             false,
         ) {
-            return ok_json(gate);
+            return err_result(gate);
         }
         tracing::info!(namespace = %p.namespace, target = %p.target, "iris_compile");
 
@@ -3252,7 +3272,7 @@ impl IrisTools {
 
         if !ns_exists {
             self.record_call("iris_test", false);
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "success": false,
                 "error_code": ERR_NAMESPACE_NOT_FOUND,
                 "error": format!("Namespace '{}' does not exist on this IRIS instance", p.namespace),
@@ -3348,7 +3368,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             match tokio::time::timeout(timeout, iris.execute(&run_code, &p.namespace)).await {
                 Err(_) => {
                     self.record_call("iris_test", false);
-                    return ok_json(serde_json::json!({
+                    return err_result(serde_json::json!({
                         "success": false,
                         "error_code": "TIMEOUT",
                         "error": format!("Test run timed out after {}s", p.timeout),
@@ -3365,7 +3385,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                         Ok(Ok(out)) => out,
                         _ => {
                             self.record_call("iris_test", false);
-                            return ok_json(serde_json::json!({
+                            return err_result(serde_json::json!({
                                 "success": false,
                                 "error_code": "DOCKER_REQUIRED",
                                 "error": format!("iris_test: IRIS_CONTAINER set but docker exec failed and HTTP fallback also failed.{DOCKER_REQUIRED_HINT}"),
@@ -3385,7 +3405,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             {
                 Err(_) => {
                     self.record_call("iris_test", false);
-                    return ok_json(serde_json::json!({
+                    return err_result(serde_json::json!({
                         "success": false,
                         "error_code": "TIMEOUT",
                         "error": format!("Test run timed out after {}s", p.timeout),
@@ -3393,7 +3413,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 }
                 Ok(Err(e)) => {
                     self.record_call("iris_test", false);
-                    return ok_json(serde_json::json!({
+                    return err_result(serde_json::json!({
                         "success": false,
                         "error_code": ERR_TEST_EXECUTION_ERROR,
                         "error": e.to_string(),
@@ -3541,7 +3561,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                  your tests directory."
                     .to_string()
             };
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "success": false,
                 "error_code": ERR_NO_TESTS_FOUND,
                 "error": "Pattern matched no test classes",
@@ -3688,7 +3708,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 None,
                 params_json,
             );
-            return ok_json(gate);
+            return err_result(gate);
         }
         if let Some(gate) = crate::iris::server_manager::policy_gate(
             "iris_execute",
@@ -3709,7 +3729,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 allowed,
                 params_json,
             );
-            return ok_json(gate);
+            return err_result(gate);
         }
         self.write_audit_entry(
             "iris_execute",
@@ -3728,7 +3748,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             &instance_name,
             false,
         ) {
-            return ok_json(gate);
+            return err_result(gate);
         }
         tracing::info!(namespace = %p.namespace, translate_sql = p.translate_sql, use_session = p.use_session, "iris_execute");
         let client = exec_client.as_ref();
@@ -3740,7 +3760,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             if let Some(ref tok) = p.session_state {
                 if let Err(e) = execute_session::SessionToken::new(tok) {
                     self.record_call("iris_execute", false);
-                    return ok_json(serde_json::json!({
+                    return err_result(serde_json::json!({
                         "success": false,
                         "error_code": "SESSION_INVALID",
                         "error": format!("invalid session_state token: {e}"),
@@ -3787,7 +3807,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         let http_err: String = match gen_result {
             Err(_) => {
                 self.record_call("iris_execute", false);
-                return ok_json(serde_json::json!({
+                return err_result(serde_json::json!({
                     "success": false,
                     "error_code": "TIMEOUT",
                     "error": format!("execution timed out after {}s", p.timeout),
@@ -3805,7 +3825,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 // take priority over normal output processing.
                 if let Some((err_code, detail)) = session_error {
                     self.record_call("iris_execute", false);
-                    return ok_json(serde_json::json!({
+                    return err_result(serde_json::json!({
                         "success": false,
                         "error_code": err_code,
                         "error": detail,
@@ -3850,7 +3870,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                         }
                     }
                 }
-                return ok_json(resp);
+                return json_result(resp);
             }
             Ok(Err(e)) => {
                 // HTTP path failed — keep the real cause; fall through to docker exec.
@@ -3864,7 +3884,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         match docker_result {
             Err(_) => {
                 self.record_call("iris_execute", false);
-                ok_json(serde_json::json!({
+                err_result(serde_json::json!({
                     "success": false,
                     "error_code": "TIMEOUT",
                     "error": format!("execution timed out after {}s", p.timeout),
@@ -3876,7 +3896,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 if msg == "DOCKER_REQUIRED" {
                     // Docker is not the real problem — HTTP is the primary path and it failed.
                     // Surface that cause instead of blaming a missing container.
-                    ok_json(serde_json::json!({
+                    err_result(serde_json::json!({
                         "success": false,
                         "error_code": "HTTP_EXECUTION_FAILED",
                         "error": format!(
@@ -3888,7 +3908,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                         "http_error": http_err,
                     }))
                 } else {
-                    ok_json(serde_json::json!({
+                    err_result(serde_json::json!({
                         "success": false,
                         "error_code": "EXECUTION_FAILED",
                         "error": msg,
@@ -3924,7 +3944,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                         }
                     }
                 }
-                ok_json(resp)
+                json_result(resp)
             }
         }
     }
@@ -3983,7 +4003,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                     None,
                     params_json,
                 );
-                return ok_json(gate);
+                return err_result(gate);
             }
             if let Some(gate) = crate::iris::server_manager::policy_gate(
                 "iris_query",
@@ -4004,7 +4024,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                     allowed,
                     params_json,
                 );
-                return ok_json(gate);
+                return err_result(gate);
             }
             self.write_audit_entry(
                 "iris_query",
@@ -4038,7 +4058,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 &instance_name,
                 false,
             ) {
-                return ok_json(gate);
+                return err_result(gate);
             }
         }
 
@@ -4088,7 +4108,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             match validate_read_only_sql(&p.query) {
                 Err(ref kw) if kw == "EMPTY" => {
                     self.record_call("iris_query", false);
-                    return ok_json(serde_json::json!({
+                    return err_result(serde_json::json!({
                         "success": false,
                         "error_code": "EMPTY_QUERY",
                         "error": "SQL query is empty after removing comments.",
@@ -4105,7 +4125,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                     if p.force && !self.write_tools_enabled() {
                         resp["force_ignored"] = serde_json::Value::Bool(true);
                     }
-                    return ok_json(resp);
+                    return err_result(resp);
                 }
                 Ok(()) => {}
             }
@@ -4272,7 +4292,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                     .iter()
                     .filter_map(|c| c["name"].as_str())
                     .collect();
-                return ok_json(serde_json::json!({
+                return err_result(serde_json::json!({
                     "success": false,
                     "error": "CONTAINER_NOT_FOUND",
                     "requested": p.name,
@@ -4299,7 +4319,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
 
         // Check if probe succeeded (version populated means reachable)
         if new_conn.version.is_none() {
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "success": false,
                 "error": "CONTAINER_UNREACHABLE",
                 "container": p.name,
@@ -4931,7 +4951,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             })?;
 
         if !validate_cls_syntax(&class_text) {
-            return ok_json(
+            return err_result(
                 serde_json::json!({"success": false, "error_code": "INVALID_OUTPUT", "raw_llm_output": class_text}),
             );
         }
@@ -5048,7 +5068,7 @@ Methods:
             })?;
 
         if !validate_cls_syntax(&test_text) {
-            return ok_json(
+            return err_result(
                 serde_json::json!({"success": false, "error_code": "INVALID_OUTPUT", "raw_llm_output": test_text}),
             );
         }
@@ -5141,7 +5161,7 @@ Methods:
         }
 
         // FR-004: never a bare miss — say where we looked.
-        ok_json(serde_json::json!({
+        err_result(serde_json::json!({
             "success": false,
             "error_code": "NOT_FOUND",
             "error": format!("Skill '{}' not found", p.name),
@@ -5766,7 +5786,7 @@ Methods:
                     None,
                     params_json,
                 );
-                return ok_json(gate);
+                return err_result(gate);
             }
             if let Some(gate) = crate::iris::server_manager::policy_gate(
                 "iris_source_control",
@@ -5787,7 +5807,7 @@ Methods:
                     allowed,
                     params_json,
                 );
-                return ok_json(gate);
+                return err_result(gate);
             }
             self.write_audit_entry(
                 "iris_source_control",
@@ -5812,7 +5832,7 @@ Methods:
                     &instance_name,
                     true,
                 ) {
-                    return ok_json(gate);
+                    return err_result(gate);
                 }
             }
         }
@@ -5877,7 +5897,7 @@ Methods:
                 None,
                 params_json.clone(),
             );
-            return ok_json(gate_err.clone());
+            return err_result(gate_err.clone());
         }
         let result = global::handle_iris_global(&iris, exec_client.as_ref(), &p, gate).await;
         self.write_audit_entry(
@@ -5893,7 +5913,7 @@ Methods:
             None,
             params_json,
         );
-        ok_json(result)
+        json_result(result)
     }
 
     // ── 064: iris_coverage ────────────────────────────────────────────────────
@@ -5908,7 +5928,7 @@ Methods:
     ) -> Result<CallToolResult, McpError> {
         let iris = self.resolve_server(p.server.as_deref()).await?;
         let result = coverage::handle_iris_coverage(&iris, &self.client, &p).await;
-        ok_json(result)
+        json_result(result)
     }
 
     // ── 065: iris_doc_search ──────────────────────────────────────────────────
@@ -5923,7 +5943,11 @@ Methods:
     ) -> Result<CallToolResult, McpError> {
         let result = doc_search::handle_iris_doc_search(&self.client, &p).await;
         self.record_call("iris_doc_search", result.get("error").is_none());
-        ok_json(result)
+        if result.get("error").is_some() {
+            err_result(result)
+        } else {
+            ok_json(result)
+        }
     }
 
     // ── 053: iris_execute_method ──────────────────────────────────────────────
@@ -5965,7 +5989,7 @@ Methods:
                 None,
                 params_json.clone(),
             );
-            return ok_json(gate_err.clone());
+            return err_result(gate_err.clone());
         }
         let result = doc::handle_iris_execute_method(&iris, exec_client.as_ref(), &p).await;
         self.record_call("iris_execute_method", result.is_ok());
@@ -6325,7 +6349,7 @@ Methods:
             policy.as_ref(),
             &params_json,
         ) {
-            return ok_json(gate);
+            return err_result(gate);
         }
         let _iris_arc_hold: Option<Arc<IrisConnection>> =
             match p.get("server").and_then(|v| v.as_str()) {
@@ -6377,7 +6401,7 @@ Methods:
             policy.as_ref(),
             &params_json,
         ) {
-            return ok_json(gate);
+            return err_result(gate);
         }
         let _iris_arc_hold: Option<Arc<IrisConnection>> =
             match p.get("server").and_then(|v| v.as_str()) {
@@ -6422,7 +6446,7 @@ Methods:
             policy.as_ref(),
             &params_json,
         ) {
-            return ok_json(gate);
+            return err_result(gate);
         }
         let _iris_arc_hold: Option<Arc<IrisConnection>> =
             match p.get("server").and_then(|v| v.as_str()) {
@@ -6913,7 +6937,7 @@ Methods:
 
         // Validate name is non-empty.
         if p.name.trim().is_empty() {
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "error_code": "INVALID_PARAMS",
                 "message": "Server name must not be empty."
             }));
@@ -6933,7 +6957,7 @@ Methods:
             },
         );
         if let Err(e) = servers_config::save_native_config(&cfg) {
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "error_code": "SAVE_FAILED",
                 "message": format!("Failed to save servers.json: {e}")
             }));
@@ -6941,7 +6965,7 @@ Methods:
 
         // Store credential in OS keychain.
         if let Err(e) = server_manager::store_credential(&p.name, &p.username, &p.password) {
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "error_code": "KEYCHAIN_FAILED",
                 "message": format!("Server added to config but keychain storage failed: {e}. \
                     You can reconnect via iris_import_servers after authenticating in VS Code Server Manager.")
@@ -6968,7 +6992,7 @@ Methods:
         // Check source — only iad-native servers can be removed.
         let source = self.pool.source_of(&p.name);
         if source != "iad-native" {
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "error_code": server_tools::REMOVE_NOT_ALLOWED,
                 "source": source,
                 "message": format!(
@@ -6982,7 +7006,7 @@ Methods:
         // Load, remove entry, save.
         let mut cfg = servers_config::load_native_config();
         if !cfg.servers.contains_key(&p.name) {
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "error_code": "SERVER_NOT_FOUND",
                 "message": format!("Server '{}' not found in iad-native config.", p.name)
             }));
@@ -6993,7 +7017,7 @@ Methods:
             cfg.default = None;
         }
         if let Err(e) = servers_config::save_native_config(&cfg) {
-            return ok_json(serde_json::json!({
+            return err_result(serde_json::json!({
                 "error_code": "SAVE_FAILED",
                 "message": format!("Failed to save servers.json: {e}")
             }));
@@ -7145,7 +7169,7 @@ Methods:
 
         if imported > 0 {
             if let Err(e) = servers_config::save_native_config(&cfg) {
-                return ok_json(serde_json::json!({
+                return err_result(serde_json::json!({
                     "error_code": "SAVE_FAILED",
                     "message": format!("Failed to save servers.json after importing: {e}")
                 }));

--- a/crates/iris-agentic-dev-core/src/tools/observability.rs
+++ b/crates/iris-agentic-dev-core/src/tools/observability.rs
@@ -14,7 +14,9 @@ pub(crate) fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> 
 }
 
 pub(crate) fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {
-    ok_json(serde_json::json!({"success": false, "error_code": code, "error": msg}))
+    crate::tools::err_result(
+        serde_json::json!({"success": false, "error_code": code, "error": msg}),
+    )
 }
 
 /// Guard: requires dataPolicy == "allow". Returns Some(blocked error) when not allowed.

--- a/crates/iris-agentic-dev-core/src/tools/scm.rs
+++ b/crates/iris-agentic-dev-core/src/tools/scm.rs
@@ -11,7 +11,9 @@ fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::Er
     ]))
 }
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    ok_json(serde_json::json!({"success": false, "error_code": code, "error": msg}))
+    crate::tools::err_result(
+        serde_json::json!({"success": false, "error_code": code, "error": msg}),
+    )
 }
 fn default_namespace() -> String {
     "USER".to_string()
@@ -152,7 +154,7 @@ pub async fn handle_iris_source_control(
                 } else {
                     ("SCM_UNAVAILABLE", msg)
                 };
-                return ok_json(
+                return crate::tools::err_result(
                     serde_json::json!({"success": false, "error_code": ec, "error": emsg}),
                 );
             }
@@ -177,7 +179,7 @@ pub async fn handle_iris_source_control(
                 Err(e) => {
                     // A transport/exec failure must NOT be reported as "editable" — that is the
                     // very inconsistency this path used to have. Surface it honestly.
-                    return ok_json(serde_json::json!({
+                    return crate::tools::err_result(serde_json::json!({
                         "success": false,
                         "error_code": "SCM_UNAVAILABLE",
                         "error": e.to_string(),
@@ -212,7 +214,7 @@ pub async fn handle_iris_source_control(
                 // authentication banner, an empty body — is diagnosable instead of being flattened
                 // into an opaque "no status signal".
                 let raw_trunc: String = raw.trim().chars().take(600).collect();
-                return ok_json(serde_json::json!({
+                return crate::tools::err_result(serde_json::json!({
                     "success": false,
                     "error_code": "SCM_UNAVAILABLE",
                     "error": "Could not determine source control status (no SCMSTATUS sentinel in IRIS output)",
@@ -222,7 +224,7 @@ pub async fn handle_iris_source_control(
             let status =
                 derive_scm_status(is_in_sc, has_co, has_undo, has_add, &owner, &iris.username);
             let Some(status) = status else {
-                return ok_json(serde_json::json!({
+                return crate::tools::err_result(serde_json::json!({
                     "success": false,
                     "error_code": "SCM_UNAVAILABLE",
                     "error": "Source control status is indeterminate for this document",
@@ -272,14 +274,14 @@ pub async fn handle_iris_source_control(
             let raw = match xecute(iris, client, &code, ns).await {
                 Ok(o) => o,
                 Err(e) => {
-                    return ok_json(
+                    return crate::tools::err_result(
                         serde_json::json!({"success": false, "error_code": "SCM_UNAVAILABLE", "error": e.to_string()}),
                     )
                 }
             };
             let out = raw.lines().next().unwrap_or("").trim();
             if out == "SCM_UNAVAILABLE" {
-                return ok_json(
+                return crate::tools::err_result(
                     serde_json::json!({"success": false, "error_code": "SCM_UNAVAILABLE", "error": "Source control session could not be initialized"}),
                 );
             }
@@ -301,7 +303,7 @@ pub async fn handle_iris_source_control(
                         }
                     }
                     Err(e) => {
-                        return ok_json(serde_json::json!({
+                        return crate::tools::err_result(serde_json::json!({
                             "success": false,
                             "error_code": "SCM_UNAVAILABLE",
                             "error": e.to_string(),
@@ -348,14 +350,14 @@ pub async fn handle_iris_source_control(
             let raw = match xecute(iris, client, &code, ns).await {
                 Ok(o) => o,
                 Err(e) => {
-                    return ok_json(
+                    return crate::tools::err_result(
                         serde_json::json!({"success": false, "error_code": "SCM_UNAVAILABLE", "error": e.to_string()}),
                     )
                 }
             };
             let out = raw.lines().next().unwrap_or("").trim();
             if out == "SCM_UNAVAILABLE" {
-                return ok_json(
+                return crate::tools::err_result(
                     serde_json::json!({"success": false, "error_code": "SCM_UNAVAILABLE", "error": "Source control session could not be initialized"}),
                 );
             }

--- a/crates/iris-agentic-dev-core/src/tools/search.rs
+++ b/crates/iris-agentic-dev-core/src/tools/search.rs
@@ -69,7 +69,7 @@ pub async fn handle_iris_search(
     let files = match resolve_files(&p.documents) {
         Some(f) => f,
         None => {
-            return ok_json(serde_json::json!({
+            return crate::tools::err_result(serde_json::json!({
                 "success": false,
                 "error_code": "SCOPE_REQUIRED",
                 "error": "iris_search requires a document scope. Namespace-wide search \
@@ -201,7 +201,7 @@ async fn poll_async_search(
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         if std::time::Instant::now() > deadline {
-            return ok_json(serde_json::json!({
+            return crate::tools::err_result(serde_json::json!({
                 "success": false,
                 "error_code": "SEARCH_TIMEOUT",
                 "error": "Async search did not complete within 5 minutes",

--- a/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
@@ -12,7 +12,9 @@ fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::Er
     ]))
 }
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    ok_json(serde_json::json!({"success": false, "error_code": code, "error": msg}))
+    crate::tools::err_result(
+        serde_json::json!({"success": false, "error_code": code, "error": msg}),
+    )
 }
 
 fn learning_enabled() -> bool {
@@ -635,6 +637,7 @@ mod tests {
     #[test]
     fn test_err_json_basic() {
         let result = err_json("TEST_CODE", "Test message").unwrap();
+        assert_eq!(result.is_error, Some(true));
         let text = result.content[0].raw.as_text().unwrap().text.clone();
         let v: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(v["success"], false);

--- a/crates/iris-agentic-dev-core/tests/integration/test_handlers_live.rs
+++ b/crates/iris-agentic-dev-core/tests/integration/test_handlers_live.rs
@@ -12961,6 +12961,13 @@ async fn test_scm_checkout_elicitation_required_via_wiremock() {
             std::env::set_var("IRIS_CONTAINER", v);
         }
     }
+    // Elicitation dialogs are a normal outcome, not a tool failure — the MCP
+    // isError flag must NOT be set (issue #95).
+    assert_ne!(
+        result.as_ref().map(|r| r.is_error).ok().flatten(),
+        Some(true),
+        "elicitation dialog must not carry isError"
+    );
     let v = parse_result(result);
     // action_code=1 → elicitation_required
     assert_eq!(


### PR DESCRIPTION
Fixes #95 — every tool failure shipped as `CallToolResult::success` carrying the `{success:false, error_code, error}` body, so the protocol-level `isError` flag never fired and spec-compliant MCP clients saw failures as successes.

## What

- **`err_result()`** builds error results via `CallToolResult::error` — the JSON body stays **byte-identical**; only the flag changes. All `err_json` helpers and per-module clones route through it, plus ~85 inline error sites (policy/dispatch gates, timeouts, `DOCKER_REQUIRED`, SQL guards, server registry, container/skill/LLM failures).
- **`json_result()`** for handler-produced bodies whose error-ness is only known at runtime: flags iff a top-level `error_code` is present without `success: true`. Used by `iris_global`, `iris_coverage`, `iris_doc_search`, and the `iris_execute` runtime-error responses.
- **Deliberately NOT flagged**: `elicitation_required` dialogs (user prompts are normal outcomes), empty-result informational notes, and failing-test/compile-diagnostic bodies (`success:false` without `error_code` — the tool itself worked). A wiremock test now pins the dialog case as unflagged.

## Verification

`cargo test --workspace`: **3866 passed / 0 failed** (assertions strengthened to the new truth; no body assertion weakened). Live stdio probe against IRIS 2026.1:

before → `{"content":[{"text":"{\"error_code\":\"SQL_ERROR\",...}"}],"isError":false}`
after → same body, `"isError":true`; successful calls unchanged.

(From the intersystems-ib interop fork team — same fix has been running there as intersystems-ib/iris-interop-dev#10 since 0.6.24; this is the port to master. Related: #92/#93 escaping, #96–#99 filed from the same audit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)