### PR TITLE
fix: honor web_port/scheme/web_prefix on operate-mode [instance.*] blocks

### DIFF
--- a/crates/iris-agentic-dev-bin/src/cmd/tool.rs
+++ b/crates/iris-agentic-dev-bin/src/cmd/tool.rs
@@ -138,8 +138,29 @@ impl ToolCommand {
             })
             .unwrap();
 
+        // Named `server=` / pool-only tools can run from `[instance.*]` even when
+        // there is no top-level host (operate-mode fleet). check_config / iris_servers
+        // never need a live default connection.
+        let allow_no_default = name == "check_config"
+            || name == "iris_servers"
+            || args_json
+                .get("server")
+                .and_then(|v| v.as_str())
+                .map(|s| !s.is_empty())
+                .unwrap_or(false)
+            || (name == "iris_test_server"
+                && args_json
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| !s.is_empty())
+                    .unwrap_or(false));
+
         let iris: Option<IrisConnection> = match self.conn.resolve().await {
             Ok(c) => Some(c),
+            Err(e) if allow_no_default => {
+                eprintln!("warning: no default IRIS connection ({e}); using connection pool");
+                None
+            }
             Err(e) => {
                 eprintln!("error: {}", e);
                 std::process::exit(1);

--- a/crates/iris-agentic-dev-core/src/iris/connection_pool.rs
+++ b/crates/iris-agentic-dev-core/src/iris/connection_pool.rs
@@ -267,9 +267,7 @@ pub fn load_pool(config_file: Option<&std::path::Path>) -> ConnectionPool {
     if let Some(fleet) = workspace_config::load_fleet_config(workspace_path_str) {
         if fleet.mode.as_deref() == Some("operate") {
             for (name, inst) in &fleet.instance {
-                let host = inst.host.as_deref().unwrap_or("localhost");
-                let port = inst.web_port.unwrap_or(52773);
-                let base_url = format!("http://{}:{}", host, port);
+                let base_url = workspace_config::instance_base_url(inst);
                 let ns = inst.namespace.as_deref().unwrap_or("USER");
                 let user = inst.username.as_deref().unwrap_or("_SYSTEM");
                 let pw = inst.password.as_deref().unwrap_or("");

--- a/crates/iris-agentic-dev-core/src/iris/workspace_config.rs
+++ b/crates/iris-agentic-dev-core/src/iris/workspace_config.rs
@@ -56,19 +56,52 @@ pub enum ConnectionRole {
 }
 
 /// Per-instance config block for `mode = "operate"` fleet configs.
+///
+/// Connection fields match top-level `WorkspaceConfig` (`web_port`, `scheme`,
+/// `web_prefix`) so SKILL.md / `iris-agentic-dev init --mode operate` snippets
+/// work. `web-port`, `web-prefix`, and `memory-home` remain accepted aliases.
 #[derive(Debug, Deserialize, Default, Clone)]
-#[serde(rename_all = "kebab-case")]
 pub struct InstanceConfig {
     pub container: Option<String>,
     pub namespace: Option<String>,
     pub host: Option<String>,
+    #[serde(alias = "port", alias = "web-port")]
     pub web_port: Option<u16>,
+    /// URL path prefix for the IRIS web gateway (same meaning as top-level `web_prefix`).
+    #[serde(alias = "web-prefix")]
+    pub web_prefix: Option<String>,
+    /// `"http"` or `"https"`. Defaults to `"http"` when building the pool URL.
+    pub scheme: Option<String>,
     pub username: Option<String>,
     pub password: Option<String>,
     #[serde(default)]
     pub role: ConnectionRole,
+    #[serde(alias = "memory-home")]
     pub memory_home: Option<String>,
     pub subject: Option<String>,
+}
+
+/// Build the Atelier base URL for a fleet `[instance.*]` block.
+///
+/// Defaults: host `localhost`, port `52773`, scheme `http`, no path prefix.
+pub fn instance_base_url(inst: &InstanceConfig) -> String {
+    let host = inst.host.as_deref().unwrap_or("localhost");
+    let port = inst.web_port.unwrap_or(52773);
+    let scheme = inst
+        .scheme
+        .as_deref()
+        .map(|s| s.trim_matches('/'))
+        .filter(|s| !s.is_empty())
+        .unwrap_or("http");
+    match inst
+        .web_prefix
+        .as_deref()
+        .map(|p| p.trim_matches('/'))
+        .filter(|p| !p.is_empty())
+    {
+        Some(prefix) => format!("{scheme}://{host}:{port}/{prefix}"),
+        None => format!("{scheme}://{host}:{port}"),
+    }
 }
 
 /// Environment template gate: controls which tool categories are available on a connection.
@@ -791,7 +824,11 @@ role = "workspace"            # "workspace" or "control-plane": no write gating
 # [instance.subject]
 # host = "subject-iris.example.com"
 # web_port = 52773
+# scheme = "https"             # omit for http (default)
+# web_prefix = ""              # gateway path prefix, if any
 # namespace = "USER"
+# username = "_SYSTEM"
+# password = "SYS"
 # role = "subject"            # destructive ops require explicit confirm: true
 # memory-home = "local"       # route AI memory writes to the 'local' instance
 # subject = "MyCustomer"      # free-form label identifying this subject
@@ -810,7 +847,26 @@ mod tests {
     // Serialize tests that mutate global env vars to avoid parallel interference.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    // ── workspace_root tests ─────────────────────────────────────────────────
+    #[test]
+    fn instance_base_url_https_with_prefix() {
+        let inst = InstanceConfig {
+            host: Some("ex.example.com".into()),
+            web_port: Some(443),
+            scheme: Some("https".into()),
+            web_prefix: Some("/hspi/".into()),
+            ..Default::default()
+        };
+        assert_eq!(instance_base_url(&inst), "https://ex.example.com:443/hspi");
+    }
+
+    #[test]
+    fn instance_base_url_defaults() {
+        let inst = InstanceConfig {
+            host: Some("prod.example.com".into()),
+            ..Default::default()
+        };
+        assert_eq!(instance_base_url(&inst), "http://prod.example.com:52773");
+    }
 
     #[test]
     fn workspace_root_env_var_overrides_all() {

--- a/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
@@ -1,8 +1,9 @@
 // Tests for workspace_config module: TOML loading, priority ordering, path resolution.
 
 use iris_agentic_dev_core::iris::workspace_config::{
-    build_workspace_config_json, load_fleet_config, load_workspace_config, validate_fleet_config,
-    workspace_config_to_connection, workspace_root, ConnectionRole, FleetConfig,
+    build_workspace_config_json, instance_base_url, load_fleet_config, load_fleet_config_from_str,
+    load_workspace_config, validate_fleet_config, workspace_config_to_connection, workspace_root,
+    ConnectionRole, FleetConfig,
 };
 use std::io::Write;
 
@@ -754,6 +755,107 @@ role = "subject"
         Some("myapp-iris")
     );
     assert_eq!(fleet.instance["prod"].role, ConnectionRole::Subject);
+    assert_eq!(
+        fleet.instance["prod"].web_port,
+        Some(52773),
+        "snake_case web_port on [instance.*] must parse (SKILL.md / init template)"
+    );
+}
+
+#[test]
+fn test_instance_web_port_snake_and_kebab_aliases() {
+    let snake = load_fleet_config_from_str(
+        r#"mode = "operate"
+[instance.a]
+host = "a.example.com"
+web_port = 443
+scheme = "https"
+"#,
+    )
+    .unwrap();
+    assert_eq!(snake.instance["a"].web_port, Some(443));
+    assert_eq!(
+        instance_base_url(&snake.instance["a"]),
+        "https://a.example.com:443"
+    );
+
+    let kebab = load_fleet_config_from_str(
+        r#"mode = "operate"
+[instance.b]
+host = "b.example.com"
+web-port = 443
+scheme = "https"
+"#,
+    )
+    .unwrap();
+    assert_eq!(kebab.instance["b"].web_port, Some(443));
+    assert_eq!(
+        instance_base_url(&kebab.instance["b"]),
+        "https://b.example.com:443"
+    );
+
+    let port_alias = load_fleet_config_from_str(
+        r#"mode = "operate"
+[instance.c]
+host = "c.example.com"
+port = 80
+"#,
+    )
+    .unwrap();
+    assert_eq!(port_alias.instance["c"].web_port, Some(80));
+    assert_eq!(
+        instance_base_url(&port_alias.instance["c"]),
+        "http://c.example.com:80"
+    );
+}
+
+#[test]
+fn test_instance_base_url_https_and_web_prefix() {
+    let fleet = load_fleet_config_from_str(
+        r#"mode = "operate"
+[instance.hspi]
+host = "exchange.staging.connect2.org"
+web_port = 443
+scheme = "https"
+web_prefix = "hspi"
+namespace = "EGCOMMUNITYPARTNERS"
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        instance_base_url(&fleet.instance["hspi"]),
+        "https://exchange.staging.connect2.org:443/hspi"
+    );
+
+    let kebab_prefix = load_fleet_config_from_str(
+        r#"mode = "operate"
+[instance.hspi]
+host = "example.com"
+web-port = 443
+web-prefix = "/hspi/"
+scheme = "https"
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        instance_base_url(&kebab_prefix.instance["hspi"]),
+        "https://example.com:443/hspi"
+    );
+}
+
+#[test]
+fn test_instance_base_url_defaults_http_52773() {
+    let fleet = load_fleet_config_from_str(
+        r#"mode = "operate"
+[instance.prod]
+host = "prod.example.com"
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        instance_base_url(&fleet.instance["prod"]),
+        "http://prod.example.com:52773"
+    );
 }
 
 // T004-c: ConnectionRole defaults to Workspace when absent


### PR DESCRIPTION
Fixes #108

## Summary

Operate-mode `[instance.*]` ignored snake_case `web_port` (`InstanceConfig` was kebab-case) and always built `http://<host>:52773`. Named `server=` routing therefore missed HTTPS gateways on 443 and non-root `web_prefix` even when the toml was correct.

This matches top-level `WorkspaceConfig` keys (including kebab-case aliases) and lets CLI pool tools run without a top-level default host.

Found by testing the **1.2.0** CLI/MCP release first: `server="prod"` resolved the instance name, then called `http://<host>:52773`. Kebab-case `web-port = 443` reached port 443 but stayed on `http://`. After this change, the same `iris_info` call uses `https://<host>:443`.

## Test plan

- [x] `cargo test -p iris-agentic-dev-core --lib instance_base_url`
- [x] `cargo test -p iris-agentic-dev-core --test test_workspace_config -- instance_web_port instance_base_url`
- [x] `cargo clippy -p iris-agentic-dev-core -p iris-agentic-dev -- -D warnings`
- [ ] CI `cargo fmt --all` / full clippy
- [x] Live: `iris_info` `what=metadata` with `server=` against an HTTPS:443 `[instance.*]` block (redacted)


Made with [Cursor](https://cursor.com)