### PR TITLE
fix(mcp): populate structuredContent for tools with outputSchema

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "iris-dev",
   "description": "MCP server and skills for InterSystems IRIS development — live IRIS interaction tools plus validated coding skills. Single binary, no Python required.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "InterSystems Corporation"
   },

--- a/crates/iris-agentic-dev-core/Cargo.toml
+++ b/crates/iris-agentic-dev-core/Cargo.toml
@@ -192,6 +192,11 @@ path = "tests/unit/test_output_schema_shapes.rs"
 required-features = ["testing"]
 
 [[test]]
+name = "test_structured_content"
+path = "tests/unit/test_structured_content.rs"
+required-features = ["testing"]
+
+[[test]]
 name = "test_list_tools_pagination"
 path = "tests/unit/test_list_tools_pagination.rs"
 

--- a/crates/iris-agentic-dev-core/src/tools/admin.rs
+++ b/crates/iris-agentic-dev-core/src/tools/admin.rs
@@ -7,9 +7,7 @@ use crate::objectscript::os_str_expr;
 use rmcp::{model::*, ErrorData as McpError};
 
 fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
-    Ok(CallToolResult::success(vec![ContentBlock::text(
-        v.to_string(),
-    )]))
+    Ok(CallToolResult::structured(v))
 }
 fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {
     crate::tools::err_result(

--- a/crates/iris-agentic-dev-core/src/tools/admin_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/admin_tools.rs
@@ -30,9 +30,7 @@ impl ConfirmEntry {
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
-    Ok(CallToolResult::success(vec![ContentBlock::text(
-        v.to_string(),
-    )]))
+    Ok(CallToolResult::structured(v))
 }
 
 fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {

--- a/crates/iris-agentic-dev-core/src/tools/comparison_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/comparison_tools.rs
@@ -253,9 +253,7 @@ pub async fn compare_namespace_impl(
 }
 
 fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
-    Ok(CallToolResult::success(vec![ContentBlock::text(
-        v.to_string(),
-    )]))
+    Ok(CallToolResult::structured(v))
 }
 
 // ── Unit tests ───────────────────────────────────────────────────────────────

--- a/crates/iris-agentic-dev-core/src/tools/dict.rs
+++ b/crates/iris-agentic-dev-core/src/tools/dict.rs
@@ -38,9 +38,7 @@ pub fn confidence_for_count(n: usize) -> f64 {
 }
 
 fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    Ok(rmcp::model::CallToolResult::success(vec![
-        rmcp::model::ContentBlock::text(v.to_string()),
-    ]))
+    Ok(rmcp::model::CallToolResult::structured(v))
 }
 
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {

--- a/crates/iris-agentic-dev-core/src/tools/doc.rs
+++ b/crates/iris-agentic-dev-core/src/tools/doc.rs
@@ -155,9 +155,7 @@ fn default_mode() -> String {
 use crate::iris::connection::IrisConnection;
 
 fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    Ok(rmcp::model::CallToolResult::success(vec![
-        rmcp::model::ContentBlock::text(v.to_string()),
-    ]))
+    Ok(rmcp::model::CallToolResult::structured(v))
 }
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     crate::tools::err_result(
@@ -173,19 +171,16 @@ fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::
 fn require_name(p: &IrisDocParams, mode: &str) -> Result<String, rmcp::model::CallToolResult> {
     match p.name.as_deref().map(str::trim) {
         Some(n) if !n.is_empty() => Ok(n.to_string()),
-        _ => Err(rmcp::model::CallToolResult::error(vec![
-            rmcp::model::ContentBlock::text(
-                serde_json::json!({
-                    "success": false,
-                    "error_code": "MISSING_PARAMS",
-                    "error": format!(
-                        "name (document) is required for mode={mode} and was empty — no request \
-                         was sent. If a previous call lost its arguments, resend with `name` set."
-                    ),
-                })
-                .to_string(),
-            ),
-        ])),
+        _ => Err(rmcp::model::CallToolResult::structured_error(
+            serde_json::json!({
+                "success": false,
+                "error_code": "MISSING_PARAMS",
+                "error": format!(
+                    "name (document) is required for mode={mode} and was empty — no request \
+                     was sent. If a previous call lost its arguments, resend with `name` set."
+                ),
+            }),
+        )),
     }
 }
 /// Map a non-2xx HTTP status to an accurate error code.
@@ -1454,7 +1449,7 @@ fn annotate_edit(
             obj.insert(k.clone(), val.clone());
         }
     }
-    rmcp::model::CallToolResult::success(vec![rmcp::model::ContentBlock::text(v.to_string())])
+    rmcp::model::CallToolResult::structured(v)
 }
 
 // ── Phase 3: mode=fragment ────────────────────────────────────────────────────

--- a/crates/iris-agentic-dev-core/src/tools/info.rs
+++ b/crates/iris-agentic-dev-core/src/tools/info.rs
@@ -10,9 +10,7 @@ use serde::Deserialize;
 use std::sync::{Arc, Mutex};
 
 fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    Ok(rmcp::model::CallToolResult::success(vec![
-        rmcp::model::ContentBlock::text(v.to_string()),
-    ]))
+    Ok(rmcp::model::CallToolResult::structured(v))
 }
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     crate::tools::err_result(

--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -5,9 +5,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
-    Ok(CallToolResult::success(vec![ContentBlock::text(
-        v.to_string(),
-    )]))
+    Ok(CallToolResult::structured(v))
 }
 fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {
     crate::tools::err_result(
@@ -3205,6 +3203,11 @@ mod tests {
         let text = result.content[0].as_text().unwrap().text.clone();
         let v: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(v["test"], "data");
+        let structured = result
+            .structured_content
+            .as_ref()
+            .expect("structured_content must be set for JSON tool results");
+        assert_eq!(structured["test"], "data");
     }
 
     #[test]
@@ -3216,6 +3219,11 @@ mod tests {
         assert_eq!(v["success"], false);
         assert_eq!(v["error_code"], "TEST_ERROR");
         assert_eq!(v["error"], "Something went wrong");
+        let structured = result
+            .structured_content
+            .as_ref()
+            .expect("structured_content must be set for JSON tool errors");
+        assert_eq!(structured["error_code"], "TEST_ERROR");
     }
 
     #[test]

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -1287,18 +1287,14 @@ pub fn telemetry_config_dir() -> std::path::PathBuf {
         .join(".iris-agentic-dev")
 }
 fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
-    Ok(CallToolResult::success(vec![ContentBlock::text(
-        v.to_string(),
-    )]))
+    Ok(CallToolResult::structured(v))
 }
 /// Wrap a genuine tool-failure envelope: same JSON body as before, but with the
 /// MCP protocol-level `isError` flag set (issue #95). Dialog/soft responses
 /// (elicitation prompts, empty-result notes) must NOT go through this — they are
 /// normal outcomes and stay `CallToolResult::success`.
 pub(crate) fn err_result(v: serde_json::Value) -> Result<CallToolResult, McpError> {
-    Ok(CallToolResult::error(vec![ContentBlock::text(
-        v.to_string(),
-    )]))
+    Ok(CallToolResult::structured_error(v))
 }
 /// Wrap a handler-produced JSON value whose error-ness is only known at runtime:
 /// a body carrying a top-level `error_code` without `success: true` is a genuine

--- a/crates/iris-agentic-dev-core/src/tools/observability.rs
+++ b/crates/iris-agentic-dev-core/src/tools/observability.rs
@@ -10,9 +10,7 @@ use rmcp::{model::*, ErrorData as McpError};
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
 pub(crate) fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
-    Ok(CallToolResult::success(vec![ContentBlock::text(
-        v.to_string(),
-    )]))
+    Ok(CallToolResult::structured(v))
 }
 
 pub(crate) fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {

--- a/crates/iris-agentic-dev-core/src/tools/scm.rs
+++ b/crates/iris-agentic-dev-core/src/tools/scm.rs
@@ -6,9 +6,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    Ok(rmcp::model::CallToolResult::success(vec![
-        rmcp::model::ContentBlock::text(v.to_string()),
-    ]))
+    Ok(rmcp::model::CallToolResult::structured(v))
 }
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     crate::tools::err_result(

--- a/crates/iris-agentic-dev-core/src/tools/search.rs
+++ b/crates/iris-agentic-dev-core/src/tools/search.rs
@@ -32,9 +32,7 @@ pub struct SearchParams {
 }
 
 fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    Ok(rmcp::model::CallToolResult::success(vec![
-        rmcp::model::ContentBlock::text(v.to_string()),
-    ]))
+    Ok(rmcp::model::CallToolResult::structured(v))
 }
 
 /// Resolve the Atelier `files` scope for a search.

--- a/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
@@ -7,9 +7,7 @@ use serde::Deserialize;
 use std::collections::VecDeque;
 
 fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    Ok(rmcp::model::CallToolResult::success(vec![
-        rmcp::model::ContentBlock::text(v.to_string()),
-    ]))
+    Ok(rmcp::model::CallToolResult::structured(v))
 }
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     crate::tools::err_result(

--- a/crates/iris-agentic-dev-core/tests/cli_dispatch_integration.rs
+++ b/crates/iris-agentic-dev-core/tests/cli_dispatch_integration.rs
@@ -222,7 +222,7 @@ fn s008_max_iterations_config_respected() {
 
     // parse_tool_invocations should return an invocation on a tool line, so
     // simulating N calls to it would produce N invocations — capped at max_iterations.
-    let tool_line = "iris-agentic-dev tool iris_compile --args '{\"doc\":\"Foo.cls\"}'".repeat(1);
+    let tool_line = "iris-agentic-dev tool iris_compile --args '{\"doc\":\"Foo.cls\"}'".to_string();
     let inv = cli_dispatch::parse_tool_invocations(&tool_line);
     assert!(!inv.is_empty()); // would trigger a loop iteration
 }

--- a/crates/iris-agentic-dev-core/tests/unit/test_structured_content.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_structured_content.rs
@@ -12,18 +12,19 @@ fn tools() -> IrisTools {
 }
 
 fn structured_body(result: &rmcp::model::CallToolResult, tool: &str) -> serde_json::Value {
-    let structured = result
-        .structured_content
-        .as_ref()
-        .unwrap_or_else(|| panic!("{tool} must return structuredContent when outputSchema is declared"));
+    let structured = result.structured_content.as_ref().unwrap_or_else(|| {
+        panic!("{tool} must return structuredContent when outputSchema is declared")
+    });
     let text = result
         .content
         .first()
         .and_then(|c| c.as_text())
         .map(|t| t.text.as_str())
-        .unwrap_or_else(|| panic!("{tool} must still return text content for backward compatibility"));
-    let from_text: serde_json::Value =
-        serde_json::from_str(text).unwrap_or_else(|e| panic!("{tool} text content must be JSON: {e}"));
+        .unwrap_or_else(|| {
+            panic!("{tool} must still return text content for backward compatibility")
+        });
+    let from_text: serde_json::Value = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("{tool} text content must be JSON: {e}"));
     assert_eq!(
         structured, &from_text,
         "{tool}: structuredContent must match serialized text content"
@@ -31,7 +32,11 @@ fn structured_body(result: &rmcp::model::CallToolResult, tool: &str) -> serde_js
     structured.clone()
 }
 
-async fn call_raw(tools: &IrisTools, tool: &str, args: serde_json::Value) -> rmcp::model::CallToolResult {
+async fn call_raw(
+    tools: &IrisTools,
+    tool: &str,
+    args: serde_json::Value,
+) -> rmcp::model::CallToolResult {
     tools
         .call_for_test(tool, args)
         .await

--- a/crates/iris-agentic-dev-core/tests/unit/test_structured_content.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_structured_content.rs
@@ -1,0 +1,69 @@
+//! MCP tools that declare `outputSchema` must return matching `structuredContent`
+//! (MCP 2025-06-18 structured tool output). Cursor and other strict clients reject
+//! `call_tool` results that advertise a schema but omit structured content.
+//!
+//! These are real `call_for_test` dispatches — the same path MCP and CLI use — with
+//! no live IRIS connection required for the tools exercised here.
+
+use iris_agentic_dev_core::tools::{IrisTools, Toolset};
+
+fn tools() -> IrisTools {
+    IrisTools::new_with_toolset(None, Toolset::Merged).expect("IrisTools::new")
+}
+
+fn structured_body(result: &rmcp::model::CallToolResult, tool: &str) -> serde_json::Value {
+    let structured = result
+        .structured_content
+        .as_ref()
+        .unwrap_or_else(|| panic!("{tool} must return structuredContent when outputSchema is declared"));
+    let text = result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.as_str())
+        .unwrap_or_else(|| panic!("{tool} must still return text content for backward compatibility"));
+    let from_text: serde_json::Value =
+        serde_json::from_str(text).unwrap_or_else(|e| panic!("{tool} text content must be JSON: {e}"));
+    assert_eq!(
+        structured, &from_text,
+        "{tool}: structuredContent must match serialized text content"
+    );
+    structured.clone()
+}
+
+async fn call_raw(tools: &IrisTools, tool: &str, args: serde_json::Value) -> rmcp::model::CallToolResult {
+    tools
+        .call_for_test(tool, args)
+        .await
+        .unwrap_or_else(|e| panic!("{tool} call failed: {e}"))
+}
+
+#[tokio::test]
+async fn test_check_config_returns_structured_content() {
+    let result = call_raw(&tools(), "check_config", serde_json::json!({})).await;
+    let body = structured_body(&result, "check_config");
+    assert!(body["host"].is_string() || body["host"].is_null());
+    assert!(body["connected"].is_boolean());
+}
+
+#[tokio::test]
+async fn test_skill_list_returns_structured_content() {
+    let result = call_raw(&tools(), "skill_list", serde_json::json!({})).await;
+    let body = structured_body(&result, "skill_list");
+    assert!(body["skills"].is_array());
+}
+
+#[tokio::test]
+async fn test_iris_symbols_local_error_returns_structured_content() {
+    let result = call_raw(
+        &tools(),
+        "iris_symbols_local",
+        serde_json::json!({
+            "query": "*.cls",
+            "workspace_path": "/nonexistent/path/xyz_9999_abc"
+        }),
+    )
+    .await;
+    let body = structured_body(&result, "iris_symbols_local");
+    assert_eq!(body["error_code"], "WORKSPACE_NOT_FOUND");
+}


### PR DESCRIPTION
Fixes #115

## Summary

- Populate MCP **`structuredContent`** on tool responses that already return JSON in text `content`.
- Completes **076 interface modernization**: tools declare `outputSchema`, but responses previously omitted structured content.
- Fixes **Cursor** Agent MCP `-32600` failures: *"Tool … has an output schema but did not return structured content"*.

## Problem

MCP **2025-06-18** structured tool output pairs `outputSchema` with `structuredContent`. Since 076 added output schemas to the tool catalog, iris-agentic-dev still built results with `CallToolResult::success(text-only)`.

Strict MCP clients — including **Cursor** — correctly reject those `call_tool` results. Tools may appear in the MCP panel (especially with an allowlist), but every invocation fails at the protocol layer.

This is a server-side gap, not a client bug. Clients that only read text `content` continue to work; clients that enforce structured output do not.

## Solution

Route shared JSON response helpers through rmcp 3.x APIs:

- `CallToolResult::structured(value)` for successes
- `CallToolResult::structured_error(value)` for tool-level errors (`isError: true`)

The JSON body is unchanged. It is now mirrored into `structuredContent` while text `content` is preserved for backward compatibility (CLI, older clients, human-readable logs).

Touched paths:

- Central helpers in `tools/mod.rs` (`ok_json`, `err_result`, `json_result` chain)
- Module-local `ok_json` duplicates (`search`, `doc`, `interop`, etc.)
- A few direct `CallToolResult::success/error` stragglers in `doc.rs`

## Testing

- [x] `cargo test -p iris-agentic-dev-core --features testing --test test_structured_content`
- [x] `cargo test -p iris-agentic-dev-core --features testing --test test_output_schema_shapes`
- [x] Manual: Cursor MCP `check_config` (and other schema-declared tools) succeed without `-32600`

## Notes

- Does **not** address large `tools/list` payloads causing some clients to show **0 enabled tools** with the full catalog — tracked in #113.
- Operate-mode role-gate false positives on shared gateway hosts — tracked in #114.