### PR TITLE
fix(pool): load fleet [instance.*] when config_file is a toml path

### DIFF
--- a/crates/iris-agentic-dev-core/src/iris/connection_pool.rs
+++ b/crates/iris-agentic-dev-core/src/iris/connection_pool.rs
@@ -263,6 +263,8 @@ pub fn load_pool(config_file: Option<&std::path::Path>) -> ConnectionPool {
     }
 
     // ── Source 3: [instance.*] blocks from workspace TOML ────────────────────
+    // `config_file` is typically the path to `.iris-agentic-dev.toml` (a file).
+    // `load_fleet_config` accepts either a workspace directory or that file path.
     let workspace_path_str = config_file.and_then(|p| p.to_str());
     if let Some(fleet) = workspace_config::load_fleet_config(workspace_path_str) {
         if fleet.mode.as_deref() == Some("operate") {
@@ -408,5 +410,71 @@ mod tests {
             conn.base_url, "http://localhost:52780",
             "native source should win over vscode source"
         );
+    }
+
+    // Fleet [instance.*] must load when callers pass the toml *file* path (not only
+    // the parent directory). Regression: load_pool used to pass config_file into
+    // load_fleet_config, which joined `.iris-agentic-dev.toml` onto the file path
+    // and silently skipped operate-mode instances — so server="<fleet-name>" failed.
+    #[test]
+    fn load_pool_includes_fleet_instances_from_config_file_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join(".iris-agentic-dev.toml");
+        std::fs::write(
+            &cfg,
+            r#"mode = "operate"
+
+[instance.iad-dev]
+host = "dev.example.com"
+web_port = 443
+scheme = "https"
+namespace = "DEVNS"
+username = "u"
+password = "p"
+
+[instance.iad-prod]
+host = "prod.example.com"
+web_port = 443
+scheme = "https"
+namespace = "PROD"
+role = "subject"
+"#,
+        )
+        .unwrap();
+
+        let pool = load_pool(Some(&cfg));
+        assert_eq!(
+            pool.source_of("iad-dev"),
+            "fleet",
+            "iad-dev must come from fleet toml"
+        );
+        assert_eq!(pool.source_of("iad-prod"), "fleet");
+        let dev = pool.get(Some("iad-dev")).expect("iad-dev in pool");
+        assert_eq!(dev.base_url, "https://dev.example.com:443");
+        assert_eq!(dev.namespace, "DEVNS");
+        let prod = pool.get(Some("iad-prod")).expect("iad-prod in pool");
+        assert_eq!(prod.base_url, "https://prod.example.com:443");
+        assert_eq!(prod.namespace, "PROD");
+    }
+
+    #[test]
+    fn load_pool_includes_fleet_instances_from_workspace_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".iris-agentic-dev.toml"),
+            r#"mode = "operate"
+
+[instance.iad-only]
+host = "only.example.com"
+web_port = 52773
+namespace = "USER"
+"#,
+        )
+        .unwrap();
+
+        let pool = load_pool(Some(dir.path()));
+        assert_eq!(pool.source_of("iad-only"), "fleet");
+        let conn = pool.get(Some("iad-only")).expect("iad-only in pool");
+        assert_eq!(conn.base_url, "http://only.example.com:52773");
     }
 }

--- a/crates/iris-agentic-dev-core/src/iris/workspace_config.rs
+++ b/crates/iris-agentic-dev-core/src/iris/workspace_config.rs
@@ -458,9 +458,23 @@ pub fn apply_explicit_config_file(
 
 /// Load `.iris-agentic-dev.toml` as a `FleetConfig` (Amendment 001).
 /// Returns `None` if the file does not exist or fails to parse (with a warning).
+///
+/// `workspace_path` may be either:
+/// - a workspace **directory** containing `.iris-agentic-dev.toml`, or
+/// - a path to the **config file itself** (e.g. what `load_pool` receives as
+///   `config_file`). Passing the file path used to silently skip fleet loading
+///   because this function joined `.iris-agentic-dev.toml` onto the file path.
 pub fn load_fleet_config(workspace_path: Option<&str>) -> Option<FleetConfig> {
     let root = workspace_root(workspace_path);
-    let config_path = if root.join(".iris-agentic-dev.toml").exists() {
+    let config_path = if root.is_file()
+        || root
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("toml"))
+    {
+        // Caller passed the toml path directly (common from `load_pool`).
+        root
+    } else if root.join(".iris-agentic-dev.toml").exists() {
         root.join(".iris-agentic-dev.toml")
     } else if root.join(".iris-dev.toml").exists() {
         root.join(".iris-dev.toml")

--- a/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
@@ -762,6 +762,32 @@ role = "subject"
     );
 }
 
+/// Passing the toml *file* path (not the parent directory) must still load fleet.
+/// `load_pool` passes `config_file` this way — without this, server= fleet routing breaks.
+#[test]
+fn test_load_fleet_config_accepts_toml_file_path() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write_toml(
+        &dir,
+        r#"mode = "operate"
+
+[instance.iad-dev]
+host = "dev.example.com"
+web_port = 443
+scheme = "https"
+namespace = "DEVNS"
+"#,
+    );
+    let file = dir.path().join(".iris-agentic-dev.toml");
+    let fleet =
+        load_fleet_config(Some(file.to_str().unwrap())).expect("fleet config loads from file path");
+    assert_eq!(fleet.mode.as_deref(), Some("operate"));
+    assert!(fleet.instance.contains_key("iad-dev"));
+    let inst = &fleet.instance["iad-dev"];
+    assert_eq!(inst.host.as_deref(), Some("dev.example.com"));
+    assert_eq!(inst.namespace.as_deref(), Some("DEVNS"));
+}
+
 #[test]
 fn test_instance_web_port_snake_and_kebab_aliases() {
     let snake = load_fleet_config_from_str(


### PR DESCRIPTION
Fixes #123

## Summary

`load_pool` passes the path to `.iris-agentic-dev.toml` into `load_fleet_config`, which previously treated that argument as a workspace **directory** and joined `.iris-agentic-dev.toml` again. Fleet instances were silently skipped, so `server="<instance>"` returned `SERVER_NOT_FOUND` even with a valid `mode = "operate"` config.

This PR makes `load_fleet_config` accept either a workspace directory or a config **file** path. Operate-mode `[instance.*]` blocks then join the connection pool as `source: "fleet"`, which is the intended way to target a named instance without rewriting the top-level default host/namespace.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p iris-agentic-dev-core --features testing -- -D warnings`
- [x] Unit tests: `load_pool_includes_fleet_instances_from_config_file_path`, `load_pool_includes_fleet_instances_from_workspace_directory`, `test_load_fleet_config_accepts_toml_file_path`
- [x] Manual: after rebuild, `iris_servers` lists fleet instances; `iris_query` with `server="<fleet-name>"` hits the correct namespace while the default connection is unchanged

## Notes

- First-wins pool ordering is unchanged (iad-native / vscode before fleet). Duplicate names across sources still prefer the earlier source.

Made with [Cursor](https://cursor.com)