### PR TITLE
fix: clippy print_literal in telemetry text table header

### DIFF
--- a/crates/iris-agentic-dev-bin/src/cmd/telemetry.rs
+++ b/crates/iris-agentic-dev-bin/src/cmd/telemetry.rs
@@ -82,8 +82,8 @@ impl ExportArgs {
             _ => {
                 // Text table
                 println!(
-                    "{:<32} {:<30} {:<8} {:<12} {:<24} {:<16} {}",
-                    "timestamp", "tool", "ok", "duration_ms", "run_id", "task_id", "condition"
+                    "{:<32} {:<30} {:<8} {:<12} {:<24} {:<16} condition",
+                    "timestamp", "tool", "ok", "duration_ms", "run_id", "task_id"
                 );
                 println!("{}", "-".repeat(140));
                 for rec in &records {


### PR DESCRIPTION
The `condition` column label in the `telemetry export` text table was passed as a `{}` argument with an empty format spec. `clippy::print_literal` rejects that, and CI runs clippy with `-D warnings`, so `master` has been failing since 219cf3e.

Folds the literal into the format string, which is the fix clippy itself suggests.

```
error: literal with an empty format string
  --> crates/iris-agentic-dev-bin/src/cmd/telemetry.rs:86:84
   = note: `-D clippy::print-literal` implied by `-D warnings`
```

Kept separate from the lint-compliance work so the CI fix can land on its own.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- `cargo test --lib --bins` 1193 passed, 0 failed

Output is unchanged: the header still renders the same seven columns in the same widths.