### PR TITLE
fix: repair the extension test suite and the 1.3.0 version mismatch

### DIFF
--- a/docs/cursor-quickstart.md
+++ b/docs/cursor-quickstart.md
@@ -55,6 +55,13 @@ curl -fsSL https://github.com/intersystems-community/iris-agentic-dev/releases/l
   -o /usr/local/bin/iris-agentic-dev && chmod +x /usr/local/bin/iris-agentic-dev
 ```
 
+### Linux arm64
+
+```bash
+curl -fsSL https://github.com/intersystems-community/iris-agentic-dev/releases/latest/download/iris-agentic-dev-linux-aarch64 \
+  -o /usr/local/bin/iris-agentic-dev && chmod +x /usr/local/bin/iris-agentic-dev
+```
+
 If `/usr/local/bin` is not writable, install under your home directory instead
 (for example `~/.local/bin/iris-agentic-dev`) and point `command` in `mcp.json`
 at that absolute path.

--- a/vscode-iris-agentic-dev/package.json
+++ b/vscode-iris-agentic-dev/package.json
@@ -4,7 +4,7 @@
   "description": "Wires iris-agentic-dev MCP tools into VS Code Copilot agent mode — automatically picks up your objectscript.conn connection. Requires the iris-agentic-dev binary on PATH or in `iris-agentic-dev.serverPath` setting.",
   "version": "0.4.30",
   "irisAgenticDev": {
-    "serverVersion": "1.2.9"
+    "serverVersion": "1.3.0"
   },
   "publisher": "intersystems-community",
   "icon": "icon.png",

--- a/vscode-iris-agentic-dev/test/managedInstall.test.cjs
+++ b/vscode-iris-agentic-dev/test/managedInstall.test.cjs
@@ -112,9 +112,10 @@ test("US1: unsupported platform/arch → returns null (no PATH, no setting)", as
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "iad-test-"));
   // We can't override process.platform, so we test via getBinaryName returning null.
   // On supported platforms, this test validates the null-safety of the fallback chain
-  // for unsupported arch. We test getBinaryName(platform, 'arm64') on linux directly.
+  // for unsupported arch. win32/arm64 is the remaining unsupported combination:
+  // linux/arm64 is a published asset now, so it no longer exercises the null path.
   const { getBinaryName } = require("../.test-out/platform.cjs");
-  const name = getBinaryName("linux", "arm64");
+  const name = getBinaryName("win32", "arm64");
   assert.equal(name, null);
   fs.rmSync(tmp, { recursive: true, force: true });
 });

--- a/vscode-iris-agentic-dev/test/platform.test.cjs
+++ b/vscode-iris-agentic-dev/test/platform.test.cjs
@@ -28,12 +28,40 @@ test("win32/x64 → windows-x86_64.exe", () => {
   );
 });
 
-test("linux/arm64 → null (unsupported)", () => {
-  assert.equal(getBinaryName("linux", "arm64"), null);
+test("linux/arm64 → linux-aarch64", () => {
+  assert.equal(
+    getBinaryName("linux", "arm64"),
+    "iris-agentic-dev-linux-aarch64"
+  );
 });
 
 test("win32/arm64 → null (unsupported)", () => {
   assert.equal(getBinaryName("win32", "arm64"), null);
+});
+
+// The release matrix publishes exactly these five assets. A name that matches
+// none of them is a 404 at auto-install time, which is the failure this module
+// exists to prevent — and the reason the linux/arm64 tests above went stale
+// without anything catching it.
+test("every non-null binary name is a published release asset", () => {
+  const published = new Set([
+    "iris-agentic-dev-linux-x86_64",
+    "iris-agentic-dev-linux-aarch64",
+    "iris-agentic-dev-macos-arm64",
+    "iris-agentic-dev-macos-x86_64",
+    "iris-agentic-dev-windows-x86_64.exe",
+  ]);
+  for (const platform of ["darwin", "linux", "win32"]) {
+    for (const arch of ["x64", "arm64"]) {
+      const name = getBinaryName(platform, arch);
+      if (name !== null) {
+        assert.ok(
+          published.has(name),
+          `${platform}/${arch} → ${name} is not a published asset`
+        );
+      }
+    }
+  }
 });
 
 // --- getDownloadUrl ---
@@ -54,6 +82,14 @@ test("getDownloadUrl win32/x64 includes .exe", () => {
   );
 });
 
+test("getDownloadUrl linux/arm64 builds correct URL", () => {
+  const url = getDownloadUrl("0.9.5", "linux", "arm64");
+  assert.equal(
+    url,
+    "https://github.com/intersystems-community/iris-agentic-dev/releases/download/v0.9.5/iris-agentic-dev-linux-aarch64"
+  );
+});
+
 test("getDownloadUrl unsupported platform → null", () => {
-  assert.equal(getDownloadUrl("0.9.5", "linux", "arm64"), null);
+  assert.equal(getDownloadUrl("0.9.5", "win32", "arm64"), null);
 });


### PR DESCRIPTION
Two release-blocking failures on `master`. `build-vsix` runs `npm test`, so no release can complete while either stands — which is why the v1.3.0 Release run failed and **no v1.3.0 release exists**.

## 1. Stale platform tests (`51e6450`)

fa44693 added `aarch64-unknown-linux-musl` and taught `getBinaryName` to return `iris-agentic-dev-linux-aarch64`, but three assertions still encoded the old "linux/arm64 is unsupported" behaviour:

| Location | Assertion | Status |
| --- | --- | --- |
| `platform.test.cjs:31` | `getBinaryName("linux","arm64") === null` | fails |
| `platform.test.cjs:58` | `getDownloadUrl(…,"linux","arm64") === null` | fails |
| `managedInstall.test.cjs:117` | same, as its unsupported-arch example | never reached |

The third was hidden: `npm test` chains the four files with `&&`, so `platform.test.cjs` failing stopped the run before `managedInstall.test.cjs` and `serverVersion.test.cjs` ever executed. That is also why issue 2 below went unnoticed.

Unsupported-arch cases now use `win32/arm64`, which genuinely has no asset.

**Added a regression guard:** a test asserting every non-null `getBinaryName` result is one of the five assets the release matrix publishes. Nothing checked that the two lists agreed, which is exactly how these assertions went stale in silence — and a name with no matching asset is a 404 at auto-install time.

## 2. serverVersion mismatch (`fdfa02c`)

`Cargo.toml` and `.claude-plugin/plugin.json` are both `1.3.0`; the extension still declared `serverVersion: 1.2.9`.

```
1.2.9 !== 1.3.0   irisAgenticDev.serverVersion must match Cargo.toml — bump both together
```

`release.yml` checks the same invariant before building, which is the direct cause of the failed v1.3.0 run. Since the extension downloads from the release tagged `v<serverVersion>`, leaving it at 1.2.9 would ship an extension pointing at the previous binary. The extension version (`0.4.30`) is a separate sequence and is untouched.

`Formula/iris-agentic-dev.rb` still reads 1.2.9 by design — `update-homebrew-tap` regenerates it from built artifacts, so it lags until a release succeeds.

## Also

Documents the arm64 Linux download in `docs/cursor-quickstart.md`, which listed x86_64 only.

## Verification

- Extension suite: **35 passed, 0 failed** across all four files (previously the run aborted after 12, with 2 failures and 2 files unreached)
- `cargo test --lib --bins`: 29 + 1193 passed, 0 failed
- `verify.sh --boundary git`: 5/5 pass

Split into two commits so the version bump can be dropped if you would rather handle release versioning separately.