### PR TITLE
fix: give iris_system_performance its gate action map (master does not compile)

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/write_gate.rs
+++ b/crates/iris-agentic-dev-core/src/tools/write_gate.rs
@@ -460,7 +460,17 @@ pub const CLASSIFICATION: &[ToolClass] = &[
     ro("iris_servers"),
     ro("iris_symbols"),
     ro("iris_symbols_local"),
-    mixed("iris_system_performance"),
+    // `status` and `last_runid` only read ^IRIS.SystemPerformance. `start` runs
+    // `Do run^SystemPerformance`, which launches a collection run and writes there, so it
+    // needs the write gate. Default Write, not ReadOnly, so a mode added later fails closed.
+    mixed(
+        "iris_system_performance",
+        &[
+            ("last_runid", WriteClass::ReadOnly),
+            ("status", WriteClass::ReadOnly),
+        ],
+        WriteClass::Write,
+    ),
     ro("iris_table_info"),
     ro("iris_test_server"),
     // Opening and closing a terminal session mutates nothing. Everything a session can do


### PR DESCRIPTION
`master` does not compile. `75b5a24` classified the new tool with `mixed("iris_system_performance")`, but `mixed` takes three arguments — the per-action map and the default class are missing:

```
error[E0061]: this function takes 3 arguments but 1 argument was supplied
   --> crates/iris-agentic-dev-core/src/tools/write_gate.rs:463:5
    |
463 |     mixed("iris_system_performance"),
    |     ^^^^^--------------------------- two arguments are missing
```

This is a hard build failure, not a lint, so `cargo build --locked --workspace` fails and the CI `test` job never reaches clippy.

## The fix

Filled in the map following the `iris_admin` convention:

```rust
mixed(
    "iris_system_performance",
    &[
        ("last_runid", WriteClass::ReadOnly),
        ("status", WriteClass::ReadOnly),
    ],
    WriteClass::Write,
),
```

- `status` and `last_runid` only read `^IRIS.SystemPerformance` → `ReadOnly`.
- `start` runs `Do run^SystemPerformance`, which launches a collection run and writes there → needs the write gate.
- Default is `Write`, not `ReadOnly`, so a mode added later **fails closed** rather than slipping past the gate.
- `Write` rather than `Destructive` because starting a run deletes nothing.

`classify()` matches `action`/`mode` case-insensitively and falls through to the default, so this behaves consistently with the other per-action entries.

## Verification

- `cargo build --locked --workspace` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --lib --bins` — 1193 passed, 0 failed, including the gate completeness test that compares `CLASSIFICATION` against `registered_tool_names()` in both directions
- docs contract test — 10/10

## One observation worth separating

The **Quality Gates** workflow passed on `75b5a24` while the tree did not compile. That suite runs prettier, markdownlint, shellcheck, the spec gate and parity — it never builds the Rust workspace, so it cannot catch this class of breakage. The `CI` workflow remains the only backstop for compilation. If you want the gate boundary to cover it, the `verify-quality` hook in `.specify/gates/policy.json` is the place to wire a build/clippy orchestrator.